### PR TITLE
import and generalize the higher-level API originally created for the Elmo driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-canopen_master
-=============
-CANOpen master protocol implementation
+# drivers/canopen_master - A CANOpen master protocol implementation
 
 This library provides the protocol layer necessary to implement a CANopen
 master. Its aim is to really only provide the interpretation to/from CAN
@@ -12,7 +10,107 @@ used by most CANopen devices.
 
 It is unlike other open-source implementations (as e.g. CAN festival) as its
 aim is not to provide a full integration stack where the driver is stored deep
-inside, but rather a "inside-out" protocol library. Rather, the application is
+inside, but rather a "inside-out" protocol library. The application is
 meant to interface with the CAN hardware, using this library as a mean to
 interpret the CAN stream. This makes is a much better target for integration
 in different "active" frameworks such as Rock
+
+## High-level Slave API
+
+The main entry point to create specific device drivers is the Slave class.
+This class provides a higher-level API on top of the basic CANOpen state
+machine and object dictionary.
+
+The general process is to
+
+1. declare objects. They are represented as C++ types.
+2. create a high-level API specific to your device that interacts with
+   the object dictionary and/or the remote device
+
+All messages received from the device should be passed to `Slave::process` so that the information they contain is saved in the object dictionary. The value
+returned by `process` allows you to query what was received, and act accordingly.
+
+### Integration
+
+Methods in `Slave` that interact with the remote device return vectors of
+`canbus::Message`. These messages are meant to be sent and acked one-by-one.
+They are all SDO messages. The general process is:
+
+~~~ cpp
+auto messages = slave.querySomething();
+for (auto msg : messages) {
+    device_driver.write(msg);
+    do {
+        // Wait for SDO ack message
+    } while (slave.process(received_can_message).isAck());
+}
+~~~
+
+The `Slave::process` method should be fed every message that is being
+received from the CAN bus. It will ignore messages that are not meant for the
+device it represents, but will process the rest and update the object
+dictionary accordingly.
+
+### Interacting with the object dictionary
+
+The Slave class maintains a representation of the "best known" state of
+the device's object dictionary. Two methods, `setRaw` and `getRaw` allow
+to access this local view to the dictionary.
+
+In addition, the class allows to interact with the remote device by querying
+for a download/upload. Whenever a SDO download reply message is passed to
+`Slave::process`, the object dictionary will be updated. This also happens
+with PDOs (see next section).
+
+Create an `Objects.hpp` file where you will define your custom objects
+using the `CANOPEN_DEFINE_OBJECT` macro, as e.g.:
+
+~~~ cpp
+CANOPEN_DEFINE_RO_OBJECT(OBJECT_ID, OBJECT_SUB_ID, Name, Type)
+CANOPEN_DEFINE_WO_OBJECT(OBJECT_ID, OBJECT_SUB_ID, Name, Type)
+CANOPEN_DEFINE_RW_OBJECT(OBJECT_ID, OBJECT_SUB_ID, Name, Type)
+~~~
+
+Name is the name you will use afterwards to access the object, Type is the
+data type inside the CANOpen dictionary itself. The slave class allows
+you to access the **local** object dictionary - that is the currently known
+values for objects in the dictionary - with
+
+~~~ cpp
+getRaw<Name>()
+setRaw<Name>(Type type);
+~~~
+
+and get the SDO messages necessary to download/upload objects with
+
+~~~ cpp
+queryUpload<Name>();
+queryDownloadRaw<Name>(Type type);
+~~~
+
+In addition, one can download the value currently stored in the local
+object dictionary with
+
+~~~ cpp
+queryDownload<Name>();
+~~~~
+
+### PDOs
+
+`Slave` provides a way to setup PDOs and handle them relatively transparently.
+
+First, one has to create a PDO mapping using the `PDOMapping` class:
+
+~~~ cpp
+PDOMapping pdo;
+pdo.add<Voltage>();
+pdo.add<Current>();
+~~~
+
+From there, call `m_can_open.configurePDO` to get the SDO messages that will set up the PDO.
+Call either `m_can_open.declareRPDOMapping` or `m_can_open.declareTPDOMapping` to let the
+object know the mapping between PDOs and objects in the dictionary. It will ensure that:
+
+- you can build the RPDOs using `getRPDOMessage` and send them on the bus
+- `Slave::process` automatically updates the object dictionary when it receives
+  a TPDO message.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,8 +1,9 @@
 rock_library(canopen_master
     SOURCES NMT.cpp SDO.cpp StateMachine.cpp Emergency.cpp PDO.cpp
-        PDOMapping.cpp Exceptions.cpp
+        PDOMapping.cpp Exceptions.cpp Slave.cpp
     HEADERS Frame.hpp NMT.hpp SDO.hpp StateMachine.hpp Exceptions.hpp
         Emergency.hpp PDO.hpp PDOMapping.hpp PDOCommunicationParameters.hpp
+        Update.hpp Slave.hpp Objects.hpp
     DEPS_PKGCONFIG canbus base-types)
 
 rock_executable(canopen_ctl Main.cpp

--- a/src/Objects.hpp
+++ b/src/Objects.hpp
@@ -1,0 +1,24 @@
+#ifndef CANOPEN_MASTER_OBJECTS_HPP
+#define CANOPEN_MASTER_OBJECTS_HPP
+
+#include <cstdint>
+#include <stdexcept>
+#include <canopen_master/Frame.hpp>
+
+namespace canopen_master {
+    #define CANOPEN_DEFINE_OBJECT(object_id, object_sub_id, name, type) \
+        struct name {\
+            static const int OBJECT_ID = object_id; \
+            static const int OBJECT_SUB_ID = object_sub_id; \
+            typedef type OBJECT_TYPE; \
+        };
+
+    CANOPEN_DEFINE_OBJECT(0x1000, 0, DeviceType,                    std::uint32_t);
+    CANOPEN_DEFINE_OBJECT(0x1001, 0, ErrorRegister,                 std::uint8_t);
+    CANOPEN_DEFINE_OBJECT(0x1002, 0, ManufacturerStatusRegister,    std::uint32_t);
+    CANOPEN_DEFINE_OBJECT(0x1016, 2, ConsumerHeartbeatTime,         std::uint32_t);
+    CANOPEN_DEFINE_OBJECT(0x1017, 0, ProducerHeartbeatTime,         std::uint32_t);
+    CANOPEN_DEFINE_OBJECT(0x1018, 4, IdentityObject,                std::uint32_t);
+}
+
+#endif

--- a/src/PDOMapping.hpp
+++ b/src/PDOMapping.hpp
@@ -6,6 +6,16 @@
 
 namespace canopen_master
 {
+    /** Builder class to build PDO mappings
+     *
+     * The process is to (1) build the mapping either by directly specifying
+     * object ID and sub-ID as well as size, or by providing an object as defined
+     * by the CANOPEN_DEFINE_OBJECT macro and (2) create the PDO configuration
+     * messages using StateMachine::configurePDO. Set the state machine up using
+     * StateMachine::declareRPDOMapping and StateMachine::declareTPDOMapping so
+     * objects get updated when PDO messages are received (in the TPDO case) and
+     * StateMachine::getRPDOMessage is able to build the PDO (in the RPDO case)
+     */
     struct PDOMapping
     {
         struct MappedObject
@@ -17,9 +27,22 @@ namespace canopen_master
 
         uint8_t currentSize = 0;
         std::vector<MappedObject> mappings;
+
+        /** Add an object to the mapping
+         */
         void add(uint16_t objectId, uint8_t subId, uint8_t size);
 
+        /** Whether this mapping is empty (contains no objects)
+         */
         bool empty() const;
+
+        /** Add an object to the mapping using a type defined with CANOPEN_DEFINE_OBJECT
+         */
+        template<typename T>
+        void add(int offsetID = 0, int offsetSubID = 0) {
+            return add(T::OBJECT_ID + offsetID, T::OBJECT_SUB_ID + offsetSubID,
+                       sizeof(typename T::OBJECT_TYPE));
+        }
     };
 }
 

--- a/src/Slave.cpp
+++ b/src/Slave.cpp
@@ -1,0 +1,61 @@
+#include <canopen_master/Slave.hpp>
+#include <canopen_master/Update.hpp>
+#include <canopen_master/Objects.hpp>
+
+using namespace canopen_master;
+
+canbus::Message canopen_master::querySync() {
+    canbus::Message msg;
+    msg.time = base::Time::now();
+    msg.can_id = 0x80;
+    msg.size = 0;
+    return msg;
+}
+
+Slave::Slave(uint8_t nodeId)
+    : mCANOpen(nodeId) {
+}
+
+Slave::~Slave() {
+
+}
+
+canbus::Message Slave::queryNodeState() const {
+    return mCANOpen.queryState();
+}
+
+canbus::Message Slave::queryNodeStateTransition(
+    NODE_STATE_TRANSITION transition
+) const {
+    return mCANOpen.queryStateTransition(transition);
+}
+
+NODE_STATE Slave::getNodeState() const {
+    return mCANOpen.getState();
+}
+
+#define CANOPEN_MODE_UPDATE_CASE(mode, update_id) \
+    case canopen_master::StateMachine::mode: \
+        update |= update_id; \
+        break;
+
+Update Slave::process(canbus::Message const& message) {
+    StateMachine::Update canUpdate = mCANOpen.process(message);
+    switch(canUpdate.mode) {
+        case StateMachine::PROCESSED_HEARTBEAT:
+            return Update::UpdatedObjects(UPDATE_HEARTBEAT);
+        case StateMachine::PROCESSED_SDO_INITIATE_DOWNLOAD:
+        {
+            // Ack of a upload request
+            auto object = canUpdate.updated[0];
+            return Update::Ack(object.first, object.second);
+        }
+
+        default:
+            return Update();
+    }
+}
+
+StateMachine& Slave::getStateMachine() {
+    return mCANOpen;
+}

--- a/src/Slave.cpp
+++ b/src/Slave.cpp
@@ -12,8 +12,8 @@ canbus::Message canopen_master::querySync() {
     return msg;
 }
 
-Slave::Slave(uint8_t nodeId)
-    : mCANOpen(nodeId) {
+Slave::Slave(StateMachine& state_machine)
+    : mCANOpen(state_machine) {
 }
 
 Slave::~Slave() {
@@ -54,8 +54,4 @@ Update Slave::process(canbus::Message const& message) {
         default:
             return Update();
     }
-}
-
-StateMachine& Slave::getStateMachine() {
-    return mCANOpen;
 }

--- a/src/Slave.hpp
+++ b/src/Slave.hpp
@@ -22,7 +22,7 @@ namespace canopen_master {
      */
     class Slave {
     public:
-        Slave(uint8_t nodeId);
+        Slave(StateMachine& state_machine);
         virtual ~Slave();
 
         /** Query the canopen node state */
@@ -122,8 +122,6 @@ namespace canopen_master {
 
         virtual Update process(canbus::Message const& message);
 
-        StateMachine& getStateMachine();
-
         /** Create the given RPDO message
          *
          * The PDO message has to have been declared first with
@@ -135,7 +133,7 @@ namespace canopen_master {
         canbus::Message getRPDOMessage(unsigned int pdoIndex);
 
     protected:
-        StateMachine mCANOpen;
+        StateMachine& mCANOpen;
     };
 
     #define CANOPEN_SDO_UPDATE_CASE(object, update_id) \

--- a/src/Slave.hpp
+++ b/src/Slave.hpp
@@ -1,0 +1,148 @@
+#ifndef CANOPEN_MASTER_SLAVE_HPP
+#define CANOPEN_MASTER_SLAVE_HPP
+
+#include <canopen_master/StateMachine.hpp>
+#include <canopen_master/Frame.hpp>
+#include <canopen_master/Update.hpp>
+#include <canopen_master/Objects.hpp>
+
+namespace canopen_master {
+    /** Create a Sync message */
+    canbus::Message querySync();
+
+    enum StandardUpdates {
+        UPDATE_HEARTBEAT      = 0x00000001,
+        UPDATE_CUSTOM_START   = 0x00000010
+    };
+
+    /**
+     * Controlling class for a single slave on the bus
+     *
+     * See the README for a more in-depth usage description
+     */
+    class Slave {
+    public:
+        Slave(uint8_t nodeId);
+        virtual ~Slave();
+
+        /** Query the canopen node state */
+        canbus::Message queryNodeState() const;
+
+        /** Return the last known node state */
+        canbus::Message queryNodeStateTransition(
+            NODE_STATE_TRANSITION transition) const;
+
+        /** Return the last known node state */
+        NODE_STATE getNodeState() const;
+
+        /** Query the upload (= read from slave) of an object
+         *
+         * @arg offsetId an offset that should be applied to the object ID
+         * @arg offsetSubId an offset that should be applied to the object sub ID
+         */
+        template<typename T>
+        canbus::Message queryUpload(int offsetId = 0, int offsetSubId = 0) const {
+            return mCANOpen.upload(T::OBJECT_ID + offsetId,
+                                   T::OBJECT_SUB_ID + offsetSubId);
+        }
+
+        /** Query the download (= write to slave) of an object as it is in the database
+         *
+         * @arg offsetId an offset that should be applied to the object ID
+         * @arg offsetSubId an offset that should be applied to the object sub ID
+         */
+        template<typename T>
+        canbus::Message queryDownload() const {
+            return mCANOpen.download(T::OBJECT_ID, T::OBJECT_SUB_ID,
+                                     get<T>());
+        }
+
+        /** Query the download (= write to slave) of an object
+         *
+         * @arg offsetId an offset that should be applied to the object ID
+         * @arg offsetSubId an offset that should be applied to the object sub ID
+         */
+        template<typename T>
+        canbus::Message queryDownload(typename T::OBJECT_TYPE value,
+                                      int offsetId = 0, int offsetSubId = 0) const {
+            return mCANOpen.download(T::OBJECT_ID + offsetId,
+                                     T::OBJECT_SUB_ID + offsetSubId,
+                                     value);
+        }
+
+        /** Get an object from the object database
+         */
+        template<typename T>
+        typename T::OBJECT_TYPE get(int offsetId = 0, int offsetSubId = 0) const {
+            return mCANOpen.get<typename T::OBJECT_TYPE>(
+                T::OBJECT_ID + offsetId, T::OBJECT_SUB_ID + offsetSubId
+            );
+        }
+
+        /** Check whether the given object has been initialized in the object database
+         *
+         * @arg offsetId an offset that should be applied to the object ID
+         * @arg offsetSubId an offset that should be applied to the object sub ID
+         */
+        template<typename T>
+        bool has(int offsetId = 0, int offsetSubId = 0) const {
+            return mCANOpen.has(T::OBJECT_ID + offsetId,
+                                T::OBJECT_SUB_ID + offsetSubId);
+        }
+
+        /** Timestamp of the last written value for the given object (might be zero)
+         *
+         * @arg offsetId an offset that should be applied to the object ID
+         * @arg offsetSubId an offset that should be applied to the object sub ID
+         */
+        template<typename T>
+        base::Time timestamp(int offsetId = 0, int offsetSubId = 0) const {
+            return mCANOpen.timestamp(T::OBJECT_ID + offsetId,
+                                      T::OBJECT_SUB_ID + offsetSubId);
+        }
+
+        template<typename T>
+        void set(typename T::OBJECT_TYPE value,
+                 base::Time const& time = base::Time::now()) {
+            return mCANOpen.set<typename T::OBJECT_TYPE>(
+                T::OBJECT_ID, T::OBJECT_SUB_ID,
+                value, time
+            );
+        }
+
+        template<typename T>
+        void set(typename T::OBJECT_TYPE value,
+                 int offsetId, int offsetSubId = 0,
+                 base::Time const& time = base::Time::now()) {
+            return mCANOpen.set<typename T::OBJECT_TYPE>(
+                T::OBJECT_ID + offsetId, T::OBJECT_SUB_ID + offsetSubId,
+                value, time
+            );
+        }
+
+        virtual Update process(canbus::Message const& message);
+
+        StateMachine& getStateMachine();
+
+        /** Create the given RPDO message
+         *
+         * The PDO message has to have been declared first with
+         * declareRPDOMessage
+         *
+         * Which messages should be sent at what frequency is a matter of
+         * documentation of the actual device driver.
+         */
+        canbus::Message getRPDOMessage(unsigned int pdoIndex);
+
+    protected:
+        StateMachine mCANOpen;
+    };
+
+    #define CANOPEN_SDO_UPDATE_CASE(object, update_id) \
+        case (static_cast<uint32_t>(object::OBJECT_ID) << 8 | object::OBJECT_SUB_ID): \
+            update |= update_id; \
+            break;
+
+}
+
+#endif

--- a/src/StateMachine.hpp
+++ b/src/StateMachine.hpp
@@ -133,7 +133,7 @@ namespace canopen_master
         canbus::Message download(uint16_t objectId, uint8_t subId, T value) const
         {
             uint8_t data[4];
-            toLittleEndian<uint16_t>(data, value);
+            toLittleEndian<T>(data, value);
             return download(objectId, subId, data, sizeof(value));
         }
 

--- a/src/Update.hpp
+++ b/src/Update.hpp
@@ -1,0 +1,71 @@
+#ifndef CANOPEN_MASTER_UPDATE_HPP
+#define CANOPEN_MASTER_UPDATE_HPP
+
+#include <cstdint>
+
+namespace canopen_master {
+    /**
+     * Class used to represent the state update as returned by
+     * Slave::process
+     */
+    class Update {
+        uint32_t mAckedObjectID;
+        uint32_t mAckedObjectSubID;
+        uint64_t mUpdatedObjects;
+
+    public:
+        static Update Ack(int objectId, int objectSubId)
+        {
+            Update update;
+            update.mAckedObjectID = objectId;
+            update.mAckedObjectSubID = objectSubId;
+            return update;
+        }
+
+        static Update UpdatedObjects(uint64_t updates)
+        {
+            Update update;
+            update.mUpdatedObjects = updates;
+            return update;
+
+        }
+        Update()
+            : mAckedObjectID(0)
+            , mAckedObjectSubID(0)
+            , mUpdatedObjects(0) {}
+
+        bool isAck() const
+        {
+            return mAckedObjectID != 0;
+        }
+
+        bool isAcked(uint16_t objectId, uint8_t objectSubID) const
+        {
+            return (mAckedObjectID == objectId) &&
+                (mAckedObjectSubID == objectSubID);
+        }
+
+        template<typename T>
+        bool isAcked(int offsetId = 0, int offsetSubId = 0) const
+        {
+            return this->isAcked(T::OBJECT_ID + offsetId, T::OBJECT_SUB_ID + offsetSubId);
+        }
+
+        bool hasOneUpdated(int64_t updateId) const
+        {
+            return (mUpdatedObjects & updateId) != 0;
+        }
+
+        bool isUpdated(uint64_t updateId) const
+        {
+            return (mUpdatedObjects & updateId) == updateId;
+        }
+
+        void merge(Update const& update)
+        {
+            mUpdatedObjects |= update.mUpdatedObjects;
+        }
+    };
+}
+
+#endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,2 +1,2 @@
-rock_gtest(suite suite.cpp test_StateMachine.cpp
+rock_gtest(suite suite.cpp test_StateMachine.cpp test_Update.cpp test_Slave.cpp
    DEPS canopen_master)

--- a/test/test_Slave.cpp
+++ b/test/test_Slave.cpp
@@ -8,10 +8,12 @@ using namespace canopen_master;
 using testing::ElementsAreArray;
 
 struct SlaveTest : public ::testing::Test {
+    StateMachine state_machine;
     Slave slave;
 
     SlaveTest()
-        : slave(42) {
+        : state_machine(42)
+        , slave(state_machine) {
     }
 };
 
@@ -88,7 +90,7 @@ TEST_F(SlaveTest, it_sets_and_gets_an_object) {
 
 TEST_F(SlaveTest, it_allows_adding_offset_to_id_and_subid_in_get_and_set) {
     slave.set<Test_100_1>(0x12345678, 1, 2);
-    ASSERT_EQ(0x12345678, slave.getStateMachine().get<uint32_t>(0x101, 3));
+    ASSERT_EQ(0x12345678, state_machine.get<uint32_t>(0x101, 3));
     auto value = slave.get<Test_100_1>(1, 2);
     ASSERT_EQ(0x12345678, value);
 }

--- a/test/test_Slave.cpp
+++ b/test/test_Slave.cpp
@@ -1,0 +1,94 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <canopen_master/Slave.hpp>
+#include <canopen_master/SDO.hpp>
+
+using namespace base;
+using namespace canopen_master;
+using testing::ElementsAreArray;
+
+struct SlaveTest : public ::testing::Test {
+    Slave slave;
+
+    SlaveTest()
+        : slave(42) {
+    }
+};
+
+CANOPEN_DEFINE_OBJECT(0x100, 1, Test_100_1, uint32_t);
+CANOPEN_DEFINE_OBJECT(0x200, 1, Test_200_1, uint32_t);
+CANOPEN_DEFINE_OBJECT(0x100, 2, Test_100_2, uint32_t);
+
+TEST_F(SlaveTest, it_returns_the_query_message_matching_the_given_object) {
+    auto query = slave.queryUpload<Test_100_1>();
+
+    ASSERT_EQ(0x100, getSDOObjectID(query));
+    ASSERT_EQ(1, getSDOObjectSubID(query));
+    ASSERT_EQ(SDO_INITIATE_DOMAIN_UPLOAD, getSDOCommand(query).command);
+}
+
+TEST_F(SlaveTest, it_allows_adding_offsets_to_id_and_subid_in_query) {
+    auto query = slave.queryUpload<Test_100_1>(1, 2);
+
+    ASSERT_EQ(0x101, getSDOObjectID(query));
+    ASSERT_EQ(3, getSDOObjectSubID(query));
+    ASSERT_EQ(SDO_INITIATE_DOMAIN_UPLOAD, getSDOCommand(query).command);
+}
+
+TEST_F(SlaveTest, it_returns_the_download_message_matching_the_given_object) {
+    canbus::Message query = slave.queryDownload<Test_100_1>(0x12345678);
+
+    ASSERT_EQ(0x100, getSDOObjectID(query));
+    ASSERT_EQ(1, getSDOObjectSubID(query));
+    ASSERT_EQ(SDO_INITIATE_DOMAIN_DOWNLOAD, getSDOCommand(query).command);
+
+    uint8_t expected[] = { 0x78, 0x56, 0x34, 0x12 };
+    ASSERT_THAT(std::vector<uint8_t>(query.data + 4, query.data + 8),
+                ElementsAreArray(expected));
+}
+
+TEST_F(SlaveTest, it_allows_adding_offsets_to_id_and_subid_in_download_query) {
+    canbus::Message query = slave.queryDownload<Test_100_1>(0x12345678, 1, 2);
+
+    ASSERT_EQ(0x101, getSDOObjectID(query));
+    ASSERT_EQ(3, getSDOObjectSubID(query));
+    ASSERT_EQ(SDO_INITIATE_DOMAIN_DOWNLOAD, getSDOCommand(query).command);
+}
+
+TEST_F(SlaveTest, it_tests_whether_an_object_is_present) {
+    ASSERT_FALSE(slave.has<Test_100_1>());
+    slave.set<Test_100_1>(0x12345678);
+    ASSERT_TRUE(slave.has<Test_100_1>());
+}
+
+TEST_F(SlaveTest, it_allows_adding_offsets_when_testing_presence) {
+    ASSERT_FALSE(slave.has<Test_100_1>(1, 3));
+    slave.set<Test_100_1>(0x12345678, 1, 3);
+    ASSERT_TRUE(slave.has<Test_100_1>(1, 3));
+}
+
+TEST_F(SlaveTest, it_returns_the_timestamp_of_the_last_set_value) {
+    ASSERT_TRUE(slave.timestamp<Test_100_1>().isNull());
+    Time time(Time::fromSeconds(100));
+    slave.set<Test_100_1>(0x12345678, time);
+    ASSERT_EQ(time, slave.timestamp<Test_100_1>());
+}
+
+TEST_F(SlaveTest, it_allows_adding_offsets_when_returning_timestamp) {
+    ASSERT_TRUE(slave.timestamp<Test_100_1>(1, 3).isNull());
+    Time time(Time::fromSeconds(100));
+    slave.set<Test_100_1>(0x12345678, 1, 3, time);
+    ASSERT_EQ(time, slave.timestamp<Test_100_1>(1, 3));
+}
+
+TEST_F(SlaveTest, it_sets_and_gets_an_object) {
+    slave.set<Test_100_1>(0x12345678);
+    ASSERT_EQ(0x12345678, slave.get<Test_100_1>());
+}
+
+TEST_F(SlaveTest, it_allows_adding_offset_to_id_and_subid_in_get_and_set) {
+    slave.set<Test_100_1>(0x12345678, 1, 2);
+    ASSERT_EQ(0x12345678, slave.getStateMachine().get<uint32_t>(0x101, 3));
+    auto value = slave.get<Test_100_1>(1, 2);
+    ASSERT_EQ(0x12345678, value);
+}

--- a/test/test_StateMachine.cpp
+++ b/test/test_StateMachine.cpp
@@ -123,6 +123,39 @@ TEST(StateMachine, download) {
     );
 }
 
+TEST(StateMachine, download_8) {
+    StateMachine machine(2);
+    canbus::Message msg = machine.download<uint8_t>(0x1801, 3, 0xFE);
+    ASSERT_EQ(msg.can_id, 0x602);
+    ASSERT_EQ(msg.size, 8);
+    EXPECT_THAT(
+        std::vector<uint8_t>(msg.data, msg.data + 8),
+        ElementsAre(0x2F, 0x01, 0x18, 0x03, 0xFE, 0x00, 0x00, 0x00)
+    );
+}
+
+TEST(StateMachine, download_16) {
+    StateMachine machine(2);
+    canbus::Message msg = machine.download<uint16_t>(0x1801, 3, 0x1234);
+    ASSERT_EQ(msg.can_id, 0x602);
+    ASSERT_EQ(msg.size, 8);
+    EXPECT_THAT(
+        std::vector<uint8_t>(msg.data, msg.data + 8),
+        ElementsAre(0x2B, 0x01, 0x18, 0x03, 0x34, 0x12, 0x00, 0x00)
+    );
+}
+
+TEST(StateMachine, download_32) {
+    StateMachine machine(2);
+    canbus::Message msg = machine.download<uint32_t>(0x1801, 3, 0x12345678);
+    ASSERT_EQ(msg.can_id, 0x602);
+    ASSERT_EQ(msg.size, 8);
+    EXPECT_THAT(
+        std::vector<uint8_t>(msg.data, msg.data + 8),
+        ElementsAre(0x23, 0x01, 0x18, 0x03, 0x78, 0x56, 0x34, 0x12)
+    );
+}
+
 TEST(StateMachine, set_and_get) {
     StateMachine machine(2);
     uint16_t value = 0x1234;

--- a/test/test_Update.cpp
+++ b/test/test_Update.cpp
@@ -1,0 +1,61 @@
+#include <gtest/gtest.h>
+#include <canopen_master/Update.hpp>
+#include <canopen_master/Objects.hpp>
+
+using namespace canopen_master;
+
+struct UpdateTest : public ::testing::Test {
+};
+
+TEST_F(UpdateTest, it_indicates_if_it_is_not_an_ack) {
+    Update update;
+    ASSERT_FALSE(update.isAck());
+}
+
+TEST_F(UpdateTest, it_indicates_if_it_is_an_ack) {
+    Update ack(Update::Ack(0x100, 1));
+    ASSERT_TRUE(ack.isAck());
+}
+
+TEST_F(UpdateTest, it_allows_to_test_which_objects_it_acked) {
+    Update ack(Update::Ack(0x100, 1));
+    ASSERT_TRUE(ack.isAcked(0x100, 1));
+    ASSERT_FALSE(ack.isAcked(0x101, 1));
+    ASSERT_FALSE(ack.isAcked(0x100, 2));
+}
+
+CANOPEN_DEFINE_OBJECT(0x100, 1, Test_100_1, uint32_t);
+CANOPEN_DEFINE_OBJECT(0x200, 1, Test_200_1, uint32_t);
+CANOPEN_DEFINE_OBJECT(0x100, 2, Test_100_2, uint32_t);
+
+TEST_F(UpdateTest, it_allows_to_test_which_objects_it_acked_from_the_object) {
+    Update ack(Update::Ack(0x100, 1));
+    ASSERT_TRUE(ack.isAcked<Test_100_1>());
+    ASSERT_FALSE(ack.isAcked<Test_200_1>());
+    ASSERT_FALSE(ack.isAcked<Test_100_2>());
+}
+
+TEST_F(UpdateTest, it_allows_to_provide_an_offset_from_the_object_type) {
+    Update ack(Update::Ack(0x200, 2));
+    ASSERT_FALSE(ack.isAcked<Test_100_1>(0x100, 0));
+    ASSERT_FALSE(ack.isAcked<Test_100_1>(0x99, 1));
+    ASSERT_TRUE(ack.isAcked<Test_100_1>(0x100, 1));
+}
+
+TEST_F(UpdateTest, it_merges_the_update_bitfields) {
+    Update update(Update::UpdatedObjects(0x7));
+    update.merge(Update::UpdatedObjects(0x8));
+    ASSERT_TRUE(update.isUpdated(0xf));
+}
+
+TEST_F(UpdateTest, it_tests_whether_all_are_updated) {
+    Update update(Update::UpdatedObjects(0x7));
+    ASSERT_TRUE(update.isUpdated(0x5));
+    ASSERT_FALSE(update.isUpdated(0xc));
+}
+
+TEST_F(UpdateTest, it_tests_whether_one_is_updated_among_many) {
+    Update update(Update::UpdatedObjects(0x3));
+    ASSERT_TRUE(update.hasOneUpdated(0x6));
+    ASSERT_FALSE(update.hasOneUpdated(0x4));
+}


### PR DESCRIPTION
This API allows to define an object dictionary and work from it,
as well as provides a pattern to process objects updates.