### PR TITLE
allow unknown size in SDO commands

### DIFF
--- a/src/SDO.cpp
+++ b/src/SDO.cpp
@@ -20,7 +20,7 @@ canbus::Message canopen_master::makeSDOInitiateDomainUpload(uint8_t nodeId, uint
 
 canbus::Message canopen_master::makeSDOInitiateDomainDownload(
     uint8_t nodeId, uint16_t objectIndex, uint8_t objectSubindex,
-    uint8_t const* data, uint32_t size
+    uint8_t const* data, uint32_t size, bool sizeInData
 ) {
     if (size > 4) {
         throw Unsupported(
@@ -31,8 +31,14 @@ canbus::Message canopen_master::makeSDOInitiateDomainDownload(
     auto msg = canbus::Message::Zeroed();
     msg.can_id = FUNCTION_SDO_RECEIVE + nodeId;
     msg.size = 8;
+
     // Immediate transfer with size
-    msg.data[0] = 0x23 | ((4-size) << 2);
+    msg.data[0] = 0x22;
+    if (sizeInData) {
+        msg.data[0] |= (1 << 0);
+        msg.data[0] |= ((4 - size) << 2);
+    }
+
     toLittleEndian<uint16_t>(msg.data + 1, objectIndex);
     toLittleEndian<uint8_t>(msg.data + 3, objectSubindex);
     std::memcpy(msg.data + 4, data, size);

--- a/src/SDO.hpp
+++ b/src/SDO.hpp
@@ -32,7 +32,7 @@ namespace canopen_master
     canbus::Message makeSDOInitiateDomainUpload(uint8_t nodeId, uint16_t objectIndex, uint8_t objectSubindex);
     SDOCommand getSDOCommand(canbus::Message const& msg);
     canbus::Message makeSDOInitiateDomainDownload(uint8_t nodeId, uint16_t objectIndex, uint8_t objectSubindex,
-        uint8_t const* data, uint32_t size
+        uint8_t const* data, uint32_t size, bool sizeInData = true
     );
 
     void parseSDODomainTransferAbort(canbus::Message const& msg);

--- a/src/Slave.cpp
+++ b/src/Slave.cpp
@@ -41,3 +41,7 @@ NODE_STATE Slave::getNodeState() const {
 StateMachine::Update Slave::process(canbus::Message const& message) {
     return mCANOpen.process(message);
 }
+
+canbus::Message Slave::getRPDOMessage(unsigned int pdoIndex) const {
+    return mCANOpen.getRPDOMessage(pdoIndex);
+}

--- a/src/Slave.hpp
+++ b/src/Slave.hpp
@@ -129,7 +129,7 @@ namespace canopen_master {
          * Which messages should be sent at what frequency is a matter of
          * documentation of the actual device driver.
          */
-        canbus::Message getRPDOMessage(unsigned int pdoIndex);
+        canbus::Message getRPDOMessage(unsigned int pdoIndex) const;
 
     protected:
         StateMachine& mCANOpen;

--- a/src/StateMachine.cpp
+++ b/src/StateMachine.cpp
@@ -74,6 +74,15 @@ uint8_t StateMachine::getNodeID() const
     return nodeId;
 }
 
+uint8_t StateMachine::getUseUnknownSizes() const
+{
+    return useUnknownSizes;
+}
+
+void StateMachine::setUseUnknownSizes(bool toggle) {
+    useUnknownSizes = toggle;
+}
+
 StateMachine::Update StateMachine::process(canbus::Message const& msg)
 {
     if (canopen_master::getNodeID(msg) == nodeId)

--- a/src/StateMachine.cpp
+++ b/src/StateMachine.cpp
@@ -165,8 +165,10 @@ StateMachine::Update StateMachine::processSDOReceive(canbus::Message const& msg)
             throw ProtocolError("received CAN message with zero timestamp");
         }
         if (cmd.size == 0) {
-            cmd.size = 4;
-            if (!has(objectId, subId)) {
+            if (has(objectId, subId)) {
+                cmd.size = sizeOf(objectId, subId);
+            } else {
+                cmd.size = 4;
                 declareInternal(objectId, subId, cmd.size, false);
             }
         }

--- a/src/StateMachine.hpp
+++ b/src/StateMachine.hpp
@@ -163,6 +163,12 @@ namespace canopen_master
         /** Returns the node ID this state machine is talking to */
         uint8_t getNodeID() const;
 
+        /** Returns whether data size field will be unset in SDO communications */
+        uint8_t getUseUnknownSizes() const;
+
+        /** Sets whether data size field will be unset in SDO communications */
+        void setUseUnknownSizes(bool toggle);
+
         /** Process a message received from nodeId */
         Update process(canbus::Message const& msg);
 

--- a/src/StateMachine.hpp
+++ b/src/StateMachine.hpp
@@ -120,10 +120,11 @@ namespace canopen_master
         PDOMappings rpdoMappings;
         PDOMappings tpdoMappings;
         Dictionary dictionary;
+        bool useUnknownSizes;
         Dictionary::iterator declareInternal(uint16_t objectId, uint8_t subId, uint8_t size);
 
     public:
-        StateMachine(uint8_t nodeId);
+        StateMachine(uint8_t nodeId, bool useUnknownSizes = false);
 
         /** Returns the time of the last state update message received */
         base::Time getLastStateUpdate() const;
@@ -228,7 +229,7 @@ namespace canopen_master
             uint16_t size = get(objectId, subId, data, 4);
             if (size == 0)
                 throw ObjectNotRead("attempting to get an object that has never been read");
-            if (size != sizeof(T))
+            if (size != sizeof(T) && !useUnknownSizes)
                 throw InvalidObjectType("unexpected requested object size in get");
 
             return fromLittleEndian<T>(data);

--- a/test/test_StateMachine.cpp
+++ b/test/test_StateMachine.cpp
@@ -156,6 +156,19 @@ TEST(StateMachine, download_32) {
     );
 }
 
+
+TEST(StateMachine, download_unknown) {
+    StateMachine machine(2, true);
+    std::vector<uint8_t> raw { 0xFE, 0x00, 0x00, 0x00 };
+    canbus::Message msg = machine.download(0x1801, 3, raw.data(), raw.size());
+    ASSERT_EQ(msg.can_id, 0x602);
+    ASSERT_EQ(msg.size, 8);
+    EXPECT_THAT(
+        std::vector<uint8_t>(msg.data, msg.data + 8),
+        ElementsAre(0x22, 0x01, 0x18, 0x03, 0xFE, 0x00, 0x00, 0x00)
+    );
+}
+
 TEST(StateMachine, set_and_get) {
     StateMachine machine(2);
     uint16_t value = 0x1234;
@@ -193,7 +206,9 @@ TEST(StateMachine, downloadOfADeclaredObject) {
 TEST(StateMachine, downloadFailsIfDeclaredSizeMismatches) {
     StateMachine machine(2);
     machine.declare(0x1801, 3, 4);
-    ASSERT_THROW(machine.download(0x1801, 3, static_cast<uint16_t>(0)), ObjectSizeMismatch);
+    ASSERT_THROW(
+        machine.download(0x1801, 3, static_cast<uint16_t>(0)),
+        ObjectSizeMismatch);
 }
 
 TEST(StateMachine, processUploadReply) {
@@ -211,6 +226,44 @@ TEST(StateMachine, processUploadReply) {
     msg.data[7] = 0x00;
     ASSERT_EQ(Update(StateMachine::PROCESSED_SDO, 0x1801, 3), machine.process(msg));
     ASSERT_EQ(0x3FE, machine.get<uint16_t>(0x1801, 3));
+}
+
+TEST(StateMachine, processUnknownSizeUploadReply) {
+    StateMachine machine(2, true);
+    canbus::Message msg;
+    msg.time = base::Time::now();
+    msg.can_id = 0x582;
+    msg.data[0] = 0x42;
+    msg.data[1] = 0x01;
+    msg.data[2] = 0x18;
+    msg.data[3] = 0x03;
+    msg.data[4] = 0xFE;
+    msg.data[5] = 0x03;
+    msg.data[6] = 0xFF;
+    msg.data[7] = 0xFF;
+    ASSERT_EQ(Update(StateMachine::PROCESSED_SDO, 0x1801, 3), machine.process(msg));
+    ASSERT_EQ(0x3FE, machine.get<uint16_t>(0x1801, 3));
+}
+
+TEST(StateMachine, processUnknownSizeUploadReplyOfAnAlreadyDefinedObject) {
+    StateMachine machine(2, true);
+    canbus::Message msg;
+    msg.time = base::Time::now();
+    msg.can_id = 0x582;
+    msg.data[0] = 0x42;
+    msg.data[1] = 0x01;
+    msg.data[2] = 0x18;
+    msg.data[3] = 0x03;
+    msg.data[4] = 0xFE;
+    msg.data[5] = 0x03;
+    msg.data[6] = 0xFF;
+    msg.data[7] = 0xFF;
+    machine.process(msg);
+
+    msg.data[4] = 0xEF;
+    msg.data[5] = 0xBE;
+    machine.process(msg);
+    ASSERT_EQ(0xBEEF, machine.get<uint16_t>(0x1801, 3));
 }
 
 TEST(StateMachine, processUploadReplyRejectsZeroUpdateTime) {

--- a/test/test_StateMachine.cpp
+++ b/test/test_StateMachine.cpp
@@ -178,6 +178,26 @@ TEST(StateMachine, set_and_get) {
     ASSERT_EQ(time, machine.timestamp(0x12, 0x1));
 }
 
+TEST(StateMachine, getDefinesSizeOfObject) {
+    StateMachine machine(2, true);
+    canbus::Message msg;
+    msg.time = base::Time::now();
+    msg.can_id = 0x582;
+    msg.data[0] = 0x42;
+    msg.data[1] = 0x01;
+    msg.data[2] = 0x18;
+    msg.data[3] = 0x03;
+    msg.data[4] = 0xEF;
+    msg.data[5] = 0xBE;
+    msg.data[6] = 0xFF;
+    msg.data[7] = 0xFF;
+    machine.process(msg);
+    ASSERT_EQ(0xBEEF, machine.get<uint16_t>(0x1801, 3));
+    ASSERT_EQ(0xBEEF, machine.get<uint16_t>(0x1801, 3));
+    ASSERT_THROW(machine.get<uint32_t>(0x1801, 3), InvalidObjectType);
+    ASSERT_THROW(machine.get<uint8_t>(0x1801, 3), InvalidObjectType);
+}
+
 TEST(StateMachine, setRejectsZeroUpdateTime) {
     StateMachine machine(2);
     uint16_t value = 0x1234;

--- a/test/test_StateMachine.cpp
+++ b/test/test_StateMachine.cpp
@@ -263,6 +263,9 @@ TEST(StateMachine, processUnknownSizeUploadReply) {
     msg.data[7] = 0xFF;
     ASSERT_EQ(Update(StateMachine::PROCESSED_SDO, 0x1801, 3), machine.process(msg));
     ASSERT_EQ(0x3FE, machine.get<uint16_t>(0x1801, 3));
+
+    // It should allow receiving with size bits unset even if we already know the size
+    ASSERT_EQ(Update(StateMachine::PROCESSED_SDO, 0x1801, 3), machine.process(msg));
 }
 
 TEST(StateMachine, processUnknownSizeUploadReplyOfAnAlreadyDefinedObject) {


### PR DESCRIPTION
The spec allows the "s" bit in sdo commands to be unset. In these cases, the number of valid bytes will be unknown to the state machine so it should store all 4 bytes. It is up to the user infer the size (tipically from the object indexes)