### PR TITLE
implement PDOMapping::MappedObject::operator ==

### DIFF
--- a/src/PDOMapping.hpp
+++ b/src/PDOMapping.hpp
@@ -23,6 +23,12 @@ namespace canopen_master
             uint16_t objectId;
             uint8_t  subId;
             uint8_t  size;
+
+            bool operator ==(MappedObject const& other) const {
+                return objectId == other.objectId &&
+                    subId == other.subId &&
+                    size == other.size;
+            }
         };
 
         uint8_t currentSize = 0;


### PR DESCRIPTION
So far, only used in tests that check that setup mappings are
as expected