### PR TITLE
fix: allow to get() an object with an integral type bigger than the object size

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,23 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "cppdbg",
+            "request": "launch",
+            "name": "(drivers/canopen_master) test/suite",
+            "program": "${rock:buildDir}/test/suite",
+            "cwd": "${rock:buildDir}",
+            "MIMode": "gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": false
+                }
+            ]
+        }
+    ]
+}

--- a/src/StateMachine.cpp
+++ b/src/StateMachine.cpp
@@ -277,6 +277,17 @@ canbus::Message StateMachine::download(uint16_t objectId,
         !useUnknownSizes);
 }
 
+void StateMachine::extendSignBit(uint8_t* data, size_t objectSize)
+{
+    if ((data[objectSize - 1] & 0x80) == 0) {
+        return;
+    }
+
+    for (size_t i = objectSize; i < 4; ++i) {
+        data[i] = 0xff;
+    }
+}
+
 uint32_t StateMachine::get(uint16_t objectId,
     uint16_t subId,
     uint8_t* data,
@@ -292,6 +303,16 @@ uint32_t StateMachine::get(uint16_t objectId,
         throw BufferSizeTooSmall("buffer size too small in get()");
     std::memcpy(data, it->second.data, actualSize);
     return actualSize;
+}
+
+uint32_t StateMachine::getObjectSize(uint16_t objectId, uint16_t subId) const
+{
+    auto it = dictionary.find(ObjectIdentifier(objectId, subId));
+    if (it == dictionary.end())
+        return 0;
+    if (it->second.lastUpdate.isNull())
+        return 0;
+    return it->second.size;
 }
 
 canbus::Message StateMachine::getRPDOMessage(unsigned int pdoIndex)

--- a/src/StateMachine.cpp
+++ b/src/StateMachine.cpp
@@ -1,28 +1,29 @@
-#include <canopen_master/StateMachine.hpp>
-#include <canopen_master/Frame.hpp>
-#include <canopen_master/SDO.hpp>
-#include <canopen_master/PDO.hpp>
-#include <canopen_master/NMT.hpp>
-#include <canopen_master/Exceptions.hpp>
-#include <canopen_master/Emergency.hpp>
-#include <canopen_master/Objects.hpp>
-#include <iostream>
-#include <cstring>
 #include <algorithm>
+#include <canopen_master/Emergency.hpp>
+#include <canopen_master/Exceptions.hpp>
+#include <canopen_master/Frame.hpp>
+#include <canopen_master/NMT.hpp>
+#include <canopen_master/Objects.hpp>
+#include <canopen_master/PDO.hpp>
+#include <canopen_master/SDO.hpp>
+#include <canopen_master/StateMachine.hpp>
+#include <cstring>
+#include <iostream>
 
 using namespace canopen_master;
 
-StateMachine::Dictionary::iterator StateMachine::declareInternal(uint16_t objectId, uint8_t subId,
-                                                                 uint8_t size, bool knownSize)
+StateMachine::Dictionary::iterator StateMachine::declareInternal(uint16_t objectId,
+    uint8_t subId,
+    uint8_t size,
+    bool knownSize)
 {
     ObjectValue value;
     value.objectId = objectId;
     value.subId = subId;
     value.size = size;
     value.knownSize = knownSize;
-    return dictionary.insert(
-        std::make_pair(ObjectIdentifier(objectId, subId), value)
-    ).first;
+    return dictionary.insert(std::make_pair(ObjectIdentifier(objectId, subId), value))
+        .first;
 }
 
 StateMachine::StateMachine(uint8_t nodeId, bool useUnknownSizes)
@@ -33,7 +34,8 @@ StateMachine::StateMachine(uint8_t nodeId, bool useUnknownSizes)
     tpdoMappings.resize(MAX_PDO);
 }
 
-void StateMachine::setQuirks(uint64_t value) {
+void StateMachine::setQuirks(uint64_t value)
+{
     this->quirks = value;
 }
 
@@ -64,8 +66,7 @@ canbus::Message StateMachine::queryState() const
     return makeNMTNodeGuard(nodeId);
 }
 
-canbus::Message StateMachine::queryStateTransition(
-    NODE_STATE_TRANSITION transition) const
+canbus::Message StateMachine::queryStateTransition(NODE_STATE_TRANSITION transition) const
 {
     return makeModuleControlCommand(transition, nodeId);
 }
@@ -80,7 +81,8 @@ uint8_t StateMachine::getUseUnknownSizes() const
     return useUnknownSizes;
 }
 
-void StateMachine::setUseUnknownSizes(bool toggle) {
+void StateMachine::setUseUnknownSizes(bool toggle)
+{
     useUnknownSizes = toggle;
 }
 
@@ -98,8 +100,7 @@ StateMachine::Update StateMachine::process(canbus::Message const& msg)
         return processHeartbeat(msg);
     if (functionCode == FUNCTION_SDO_TRANSMIT)
         return processSDOReceive(msg);
-    if (isPDOTransmit(functionCode))
-    {
+    if (isPDOTransmit(functionCode)) {
         int pdoIndex = getPDOIndex(functionCode);
         return processPDOReceive(pdoIndex, msg);
     }
@@ -126,7 +127,8 @@ StateMachine::Update StateMachine::processHeartbeat(canbus::Message const& msg)
     return Update(PROCESSED_HEARTBEAT);
 }
 
-StateMachine::Update StateMachine::processPDOReceive(int pdoIndex, canbus::Message const& msg)
+StateMachine::Update StateMachine::processPDOReceive(int pdoIndex,
+    canbus::Message const& msg)
 {
     if (tpdoMappings.size() < pdoIndex + 1u)
         return Update(PROCESSED_PDO_UNEXPECTED);
@@ -134,8 +136,7 @@ StateMachine::Update StateMachine::processPDOReceive(int pdoIndex, canbus::Messa
 
     Update update(PROCESSED_PDO);
     int offset = 0;
-    for (const auto m : mapping.mappings)
-    {
+    for (const auto m : mapping.mappings) {
         setObjectValue(m.objectId, m.subId, msg.time, msg.data + offset, m.size);
         offset += m.size;
         update.addUpdate(m.objectId, m.subId);
@@ -151,28 +152,27 @@ StateMachine::Update StateMachine::processPDOReceive(int pdoIndex, canbus::Messa
 StateMachine::Update StateMachine::processSDOReceive(canbus::Message const& msg)
 {
     SDOCommand cmd = getSDOCommand(msg);
-    if (cmd.command == SDO_ABORT_DOMAIN_TRANSFER)
-    {
+    if (cmd.command == SDO_ABORT_DOMAIN_TRANSFER) {
         parseSDODomainTransferAbort(msg);
         // never returns
         return Update();
     }
-    if (cmd.command == SDO_INITIATE_DOMAIN_UPLOAD_REPLY)
-    {
-        if (!cmd.expedited_transfer)
-        {
-            std::cerr << "can_master::StateMachine nodeId=" << nodeId << " ignored non-expedited SDO transfer" << std::endl;
+    if (cmd.command == SDO_INITIATE_DOMAIN_UPLOAD_REPLY) {
+        if (!cmd.expedited_transfer) {
+            std::cerr << "can_master::StateMachine nodeId=" << nodeId
+                      << " ignored non-expedited SDO transfer" << std::endl;
             return Update();
         }
         uint16_t objectId = getSDOObjectID(msg);
-        uint8_t  subId    = getSDOObjectSubID(msg);
+        uint8_t subId = getSDOObjectSubID(msg);
         if (msg.time.isNull()) {
             throw ProtocolError("received CAN message with zero timestamp");
         }
         if (cmd.size == 0) {
             if (has(objectId, subId)) {
                 cmd.size = sizeOf(objectId, subId);
-            } else {
+            }
+            else {
                 cmd.size = 4;
                 declareInternal(objectId, subId, cmd.size, false);
             }
@@ -180,21 +180,24 @@ StateMachine::Update StateMachine::processSDOReceive(canbus::Message const& msg)
         setObjectValue(objectId, subId, msg.time, msg.data + 4, cmd.size);
         return Update(PROCESSED_SDO, objectId, subId);
     }
-    else if (cmd.command == SDO_INITIATE_DOMAIN_DOWNLOAD_REPLY)
-    {
+    else if (cmd.command == SDO_INITIATE_DOMAIN_DOWNLOAD_REPLY) {
         uint16_t objectId = getSDOObjectID(msg);
-        uint8_t  subId    = getSDOObjectSubID(msg);
+        uint8_t subId = getSDOObjectSubID(msg);
         return Update(PROCESSED_SDO_INITIATE_DOWNLOAD, objectId, subId);
     }
-    else
-    {
-        std::cerr << "can_master::StateMachine nodeId=" << nodeId << " ignored SDO command " << cmd.command << std::endl;
+    else {
+        std::cerr << "can_master::StateMachine nodeId=" << nodeId
+                  << " ignored SDO command " << cmd.command << std::endl;
         return Update(PROCESSED_SDO_IGNORED_COMMAND);
     }
     return Update(PROCESSED_SDO_UNKNOWN_COMMAND);
 }
 
-void StateMachine::setObjectValue(uint16_t objectId, uint8_t subId, base::Time const& time, uint8_t const* data, uint32_t dataSize)
+void StateMachine::setObjectValue(uint16_t objectId,
+    uint8_t subId,
+    base::Time const& time,
+    uint8_t const* data,
+    uint32_t dataSize)
 {
     auto dictionary_it = dictionary.find(ObjectIdentifier(objectId, subId));
     if (dictionary_it == dictionary.end())
@@ -207,8 +210,7 @@ void StateMachine::setObjectValue(uint16_t objectId, uint8_t subId, base::Time c
 
     if (time.isNull()) {
         throw std::invalid_argument(
-            "attempting to set an object with a zero update time"
-        );
+            "attempting to set an object with a zero update time");
     }
 
     value.lastUpdate = time;
@@ -244,7 +246,8 @@ base::Time StateMachine::timestamp(uint16_t objectId, uint8_t subId) const
     auto it = dictionary.find(ObjectIdentifier(objectId, subId));
     if (it == dictionary.end())
         return base::Time();
-    else return it->second.lastUpdate;
+    else
+        return it->second.lastUpdate;
 }
 
 canbus::Message StateMachine::sync()
@@ -256,16 +259,28 @@ canbus::Message StateMachine::sync()
     return msg;
 }
 
-canbus::Message StateMachine::download(uint16_t objectId, uint8_t subId, uint8_t const* data, uint32_t size) const
+canbus::Message StateMachine::download(uint16_t objectId,
+    uint8_t subId,
+    uint8_t const* data,
+    uint32_t size) const
 {
     uint32_t knownSize = sizeOf(objectId, subId);
     if (knownSize && knownSize != size)
-        throw ObjectSizeMismatch("attempting to write to a SDO object that has a mismatched size");
+        throw ObjectSizeMismatch(
+            "attempting to write to a SDO object that has a mismatched size");
 
-    return makeSDOInitiateDomainDownload(nodeId, objectId, subId, data, size, !useUnknownSizes);
+    return makeSDOInitiateDomainDownload(nodeId,
+        objectId,
+        subId,
+        data,
+        size,
+        !useUnknownSizes);
 }
 
-uint32_t StateMachine::get(uint16_t objectId, uint16_t subId, uint8_t* data, uint32_t bufferSize) const
+uint32_t StateMachine::get(uint16_t objectId,
+    uint16_t subId,
+    uint8_t* data,
+    uint32_t bufferSize) const
 {
     auto it = dictionary.find(ObjectIdentifier(objectId, subId));
     if (it == dictionary.end())
@@ -290,8 +305,7 @@ canbus::Message StateMachine::getRPDOMessage(unsigned int pdoIndex)
     msg.can_id = getPDODefaultCOBID(false, pdoIndex, nodeId);
 
     int offset = 0;
-    for (const auto m : mapping.mappings)
-    {
+    for (const auto m : mapping.mappings) {
         get(m.objectId, m.subId, msg.data + offset, m.size);
         offset += m.size;
     }
@@ -301,30 +315,41 @@ canbus::Message StateMachine::getRPDOMessage(unsigned int pdoIndex)
 
 void StateMachine::validatePDOMapping(PDOMapping const& mapping) const
 {
-    for (const auto m : mapping.mappings)
-    {
+    for (const auto m : mapping.mappings) {
         uint32_t knownSize = sizeOf(m.objectId, m.subId);
         if (knownSize && m.size != knownSize)
-            throw ObjectSizeMismatch("size mismatch between the PDO mapping and the registered entry");
+            throw ObjectSizeMismatch(
+                "size mismatch between the PDO mapping and the registered entry");
     }
 }
 
-canbus::Message StateMachine::disablePDO(bool transmit, uint8_t pdoIndex, uint32_t cob_id) const
+canbus::Message StateMachine::disablePDO(bool transmit,
+    uint8_t pdoIndex,
+    uint32_t cob_id) const
 {
-    return disablePDOMessage(transmit, nodeId, pdoIndex, cob_id,
-                             quirks & PDO_COBID_MESSAGE_RESERVED_BIT_QUIRK);
+    return disablePDOMessage(transmit,
+        nodeId,
+        pdoIndex,
+        cob_id,
+        quirks & PDO_COBID_MESSAGE_RESERVED_BIT_QUIRK);
 }
 
-std::vector<canbus::Message> StateMachine::configurePDO(bool transmit, uint8_t pdoIndex,
-    PDOCommunicationParameters const& parameters, PDOMapping const& mapping) const
+std::vector<canbus::Message> StateMachine::configurePDO(bool transmit,
+    uint8_t pdoIndex,
+    PDOCommunicationParameters const& parameters,
+    PDOMapping const& mapping) const
 {
-    return makePDOConfigurationMessages(
-        transmit, nodeId, pdoIndex, parameters, mapping,
-        quirks & PDO_COBID_MESSAGE_RESERVED_BIT_QUIRK
-    );
+    return makePDOConfigurationMessages(transmit,
+        nodeId,
+        pdoIndex,
+        parameters,
+        mapping,
+        quirks & PDO_COBID_MESSAGE_RESERVED_BIT_QUIRK);
 }
 
-std::vector<canbus::Message> StateMachine::configurePDOMapping(bool transmit, uint8_t pdoIndex, PDOMapping const& mapping) const
+std::vector<canbus::Message> StateMachine::configurePDOMapping(bool transmit,
+    uint8_t pdoIndex,
+    PDOMapping const& mapping) const
 {
     validatePDOMapping(mapping);
     return makePDOMappingMessages(transmit, nodeId, pdoIndex, mapping);
@@ -340,7 +365,8 @@ void StateMachine::declareRPDOMapping(uint8_t pdoIndex, PDOMapping const& mappin
     declarePDOMapping(pdoIndex, mapping, rpdoMappings);
 }
 
-void StateMachine::declarePDOMapping(uint8_t pdoIndex, PDOMapping const& mapping,
+void StateMachine::declarePDOMapping(uint8_t pdoIndex,
+    PDOMapping const& mapping,
     std::vector<PDOMapping>& mappings)
 {
     validatePDOMapping(mapping);
@@ -353,16 +379,23 @@ void StateMachine::declarePDOMapping(uint8_t pdoIndex, PDOMapping const& mapping
     mappings[pdoIndex] = mapping;
 }
 
-std::vector<canbus::Message> StateMachine::configurePDOParameters(bool transmit, uint8_t pdoIndex, PDOCommunicationParameters const& parameters) const
+std::vector<canbus::Message> StateMachine::configurePDOParameters(bool transmit,
+    uint8_t pdoIndex,
+    PDOCommunicationParameters const& parameters) const
 {
     return makePDOCommunicationParametersMessages(transmit, nodeId, pdoIndex, parameters);
 }
 
-
 StateMachine::Update::Update()
-    : mode(PROCESSED_IGNORED_MESSAGE), update_count(0) {}
+    : mode(PROCESSED_IGNORED_MESSAGE)
+    , update_count(0)
+{
+}
 StateMachine::Update::Update(UPDATE_EVENT mode)
-    : mode(mode), update_count(0) {}
+    : mode(mode)
+    , update_count(0)
+{
+}
 StateMachine::Update::Update(UPDATE_EVENT mode, uint16_t objectId, uint8_t subId)
     : StateMachine::Update::Update(mode)
 {
@@ -382,17 +415,13 @@ bool StateMachine::Update::hasUpdatedObjects() const
 
 bool StateMachine::Update::hasUpdatedObject(uint16_t objectId, int8_t subId) const
 {
-    return find(updated, updated + update_count,
-                ObjectIdentifier(objectId, subId))
-           != updated + update_count;
+    return find(updated, updated + update_count, ObjectIdentifier(objectId, subId)) !=
+           updated + update_count;
 }
 
-bool StateMachine::Update::operator ==(Update const& other) const
+bool StateMachine::Update::operator==(Update const& other) const
 {
     if (mode != other.mode || update_count != other.update_count)
         return false;
-    return std::equal(
-        updated, updated + update_count,
-        other.updated
-    );
+    return std::equal(updated, updated + update_count, other.updated);
 }

--- a/src/StateMachine.hpp
+++ b/src/StateMachine.hpp
@@ -1,26 +1,24 @@
 #ifndef CANOPEN_MASTER_STATE_MACHINE_HPP
 #define CANOPEN_MASTER_STATE_MACHINE_HPP
 
-#include <map>
-#include <vector>
 #include <base/Time.hpp>
 #include <canmessage.hh>
-#include <canopen_master/Frame.hpp>
 #include <canopen_master/Exceptions.hpp>
-#include <canopen_master/PDOMapping.hpp>
+#include <canopen_master/Frame.hpp>
 #include <canopen_master/PDOCommunicationParameters.hpp>
+#include <canopen_master/PDOMapping.hpp>
+#include <map>
+#include <vector>
 
-namespace canopen_master
-{
-    /** A state machine that handles data transfers between a CANOpen server and the master
+namespace canopen_master {
+    /** A state machine that handles data transfers between a CANOpen server and the
+     * master
      */
-    class StateMachine
-    {
+    class StateMachine {
     public:
         typedef std::pair<uint16_t, uint8_t> ObjectIdentifier;
 
-        enum UPDATE_EVENT
-        {
+        enum UPDATE_EVENT {
             PROCESSED_IGNORED_MESSAGE,
             /** Message was not from the node handled by this StateMachine */
             PROCESSED_NOT_FOR_ME,
@@ -48,8 +46,7 @@ namespace canopen_master
             PDO_COBID_MESSAGE_RESERVED_BIT_QUIRK = 0x1
         };
 
-        struct Update
-        {
+        struct Update {
             UPDATE_EVENT mode;
             int update_count;
             ObjectIdentifier updated[8];
@@ -65,10 +62,11 @@ namespace canopen_master
              * Adds an object to the update set using a type representing the
              * dictionary object
              */
-            template<typename T>
-            void addUpdate(uint16_t objectIdOffset = 0, int8_t subIdOffset = 0) {
+            template <typename T>
+            void addUpdate(uint16_t objectIdOffset = 0, int8_t subIdOffset = 0)
+            {
                 return addUpdate(T::OBJECT_ID + objectIdOffset,
-                                 T::OBJECT_SUB_ID + subIdOffset);
+                    T::OBJECT_SUB_ID + subIdOffset);
             }
 
             /** Whether this update has updated objects */
@@ -78,19 +76,31 @@ namespace canopen_master
             bool hasUpdatedObject(uint16_t objectId, int8_t subId) const;
 
             /** Whether this update has updated objects */
-            template<typename T>
-            bool hasUpdatedObject(int objectIdOffset = 0,
-                                  int objectSubIdOffset = 0) const {
+            template <typename T>
+            bool hasUpdatedObject(int objectIdOffset = 0, int objectSubIdOffset = 0) const
+            {
                 return hasUpdatedObject(T::OBJECT_ID + objectIdOffset,
-                                        T::OBJECT_SUB_ID + objectSubIdOffset);
+                    T::OBJECT_SUB_ID + objectSubIdOffset);
             }
 
-            bool operator ==(Update const& other) const;
+            bool operator==(Update const& other) const;
 
-            ObjectIdentifier* begin() { return updated; }
-            ObjectIdentifier* end() { return updated + update_count; }
-            const ObjectIdentifier* begin() const { return updated; }
-            const ObjectIdentifier* end() const { return updated + update_count; }
+            ObjectIdentifier* begin()
+            {
+                return updated;
+            }
+            ObjectIdentifier* end()
+            {
+                return updated + update_count;
+            }
+            const ObjectIdentifier* begin() const
+            {
+                return updated;
+            }
+            const ObjectIdentifier* end() const
+            {
+                return updated + update_count;
+            }
         };
 
     private:
@@ -100,8 +110,7 @@ namespace canopen_master
 
         uint64_t quirks = 0;
 
-        struct ObjectValue
-        {
+        struct ObjectValue {
             uint16_t objectId;
             uint8_t subId;
 
@@ -123,12 +132,10 @@ namespace canopen_master
         PDOMappings tpdoMappings;
         Dictionary dictionary;
         bool useUnknownSizes;
-        Dictionary::iterator declareInternal(
-            uint16_t objectId,
+        Dictionary::iterator declareInternal(uint16_t objectId,
             uint8_t subId,
             uint8_t size,
-            bool knownSize
-        );
+            bool knownSize);
 
     public:
         StateMachine(uint8_t nodeId, bool useUnknownSizes = false);
@@ -179,10 +186,13 @@ namespace canopen_master
          *
          * @throw InvalidObjectType
          */
-        canbus::Message download(uint16_t objectId, uint8_t subId, uint8_t const* value, uint32_t size) const;
+        canbus::Message download(uint16_t objectId,
+            uint8_t subId,
+            uint8_t const* value,
+            uint32_t size) const;
 
         /** Request writing the given dictionary object */
-        template<typename T>
+        template <typename T>
         canbus::Message download(uint16_t objectId, uint8_t subId, T value) const
         {
             uint8_t data[4];
@@ -222,11 +232,16 @@ namespace canopen_master
         static canbus::Message sync();
 
         /** Get raw data from a given object */
-        uint32_t get(uint16_t objectId, uint16_t subId, uint8_t* data, uint32_t bufferSize) const;
+        uint32_t get(uint16_t objectId,
+            uint16_t subId,
+            uint8_t* data,
+            uint32_t bufferSize) const;
 
         /** Set an object's value in the dictionary */
-        template<typename T>
-        void set(uint16_t objectId, uint8_t subId, T value,
+        template <typename T>
+        void set(uint16_t objectId,
+            uint8_t subId,
+            T value,
             base::Time const& time = base::Time::now())
         {
             uint8_t buffer[sizeof(value)];
@@ -235,19 +250,20 @@ namespace canopen_master
         }
 
         /** Get the currently known value for the given object */
-        template<typename T>
-        T get(uint16_t objectId, uint8_t subId) const
+        template <typename T> T get(uint16_t objectId, uint8_t subId) const
         {
             uint8_t data[4];
             uint16_t size = get(objectId, subId, data, 4);
             if (size == 0)
-                throw ObjectNotRead("attempting to get an object that has never been read");
+                throw ObjectNotRead(
+                    "attempting to get an object that has never been read");
 
             const ObjectValue& object =
                 dictionary.find(ObjectIdentifier(objectId, subId))->second;
             if (size != sizeof(T) && object.knownSize) {
                 throw InvalidObjectType("unexpected requested object size in get");
-            } else if (!object.knownSize) {
+            }
+            else if (!object.knownSize) {
                 object.size = sizeof(T);
                 object.knownSize = true;
             }
@@ -255,19 +271,24 @@ namespace canopen_master
         }
 
         /** Disable a previously configured PDO */
-        canbus::Message disablePDO(bool transmit, uint8_t pdoIndex,
+        canbus::Message disablePDO(bool transmit,
+            uint8_t pdoIndex,
             uint32_t cob_id = 0) const;
 
         /** Configures a whole PDO */
-        std::vector<canbus::Message> configurePDO(bool transmit, uint8_t pdoIndex,
-            PDOCommunicationParameters const& parameters, PDOMapping const& mapping) const;
+        std::vector<canbus::Message> configurePDO(bool transmit,
+            uint8_t pdoIndex,
+            PDOCommunicationParameters const& parameters,
+            PDOMapping const& mapping) const;
 
         /** Configure the communication parameters for the given PDO */
-        std::vector<canbus::Message> configurePDOParameters(bool transmit, uint8_t pdoIndex,
+        std::vector<canbus::Message> configurePDOParameters(bool transmit,
+            uint8_t pdoIndex,
             PDOCommunicationParameters const& parameters) const;
 
         /** Configures the mapping for one of the predefined PDOs */
-        std::vector<canbus::Message> configurePDOMapping(bool transmit, uint8_t pdoIndex,
+        std::vector<canbus::Message> configurePDOMapping(bool transmit,
+            uint8_t pdoIndex,
             PDOMapping const& mapping) const;
 
         /** Declare a TPDO mapping to the state machine
@@ -298,10 +319,15 @@ namespace canopen_master
         Update processSDOReceive(canbus::Message const& msg);
         Update processHeartbeat(canbus::Message const& msg);
         Update processPDOReceive(int pdoIndex, canbus::Message const& msg);
-        void setObjectValue(uint16_t objectId, uint8_t subId, base::Time const& time, uint8_t const* data, uint32_t dataSize);
+        void setObjectValue(uint16_t objectId,
+            uint8_t subId,
+            base::Time const& time,
+            uint8_t const* data,
+            uint32_t dataSize);
 
         /** Helper method for declareTPDOMapping and declareRPDOMapping */
-        void declarePDOMapping(uint8_t pdoIndex, PDOMapping const& mapping,
+        void declarePDOMapping(uint8_t pdoIndex,
+            PDOMapping const& mapping,
             std::vector<PDOMapping>& mappings);
     };
 }

--- a/test/test_StateMachine.cpp
+++ b/test/test_StateMachine.cpp
@@ -1,8 +1,8 @@
-#include "gtest/gtest.h"
 #include "gmock/gmock.h"
-#include <canopen_master/StateMachine.hpp>
-#include <canopen_master/SDO.hpp>
+#include "gtest/gtest.h"
 #include <canopen_master/Objects.hpp>
+#include <canopen_master/SDO.hpp>
+#include <canopen_master/StateMachine.hpp>
 
 using namespace std;
 using namespace canopen_master;
@@ -15,7 +15,8 @@ TEST(StateMachine, hasNoStateBeforeTheFirstMessage)
     ASSERT_EQ(false, machine.hasState());
 }
 
-TEST(StateMachine, queryStateTransition) {
+TEST(StateMachine, queryStateTransition)
+{
     StateMachine machine(2);
     canbus::Message msg = machine.queryStateTransition(NODE_START);
     ASSERT_EQ(msg.can_id, 0);
@@ -24,14 +25,16 @@ TEST(StateMachine, queryStateTransition) {
     ASSERT_EQ(msg.data[1], 2);
 }
 
-TEST(StateMachine, queryState) {
+TEST(StateMachine, queryState)
+{
     StateMachine machine(2);
     canbus::Message msg = machine.queryState();
     ASSERT_EQ(msg.can_id, 0x702);
     ASSERT_EQ(msg.size, 0);
 }
 
-TEST(StateMachine, bootupMessageHandling) {
+TEST(StateMachine, bootupMessageHandling)
+{
     StateMachine machine(2);
     canbus::Message msg;
     msg.time = base::Time::now();
@@ -44,7 +47,8 @@ TEST(StateMachine, bootupMessageHandling) {
     ASSERT_EQ(NODE_INITIALIZING, machine.getState());
 }
 
-TEST(StateMachine, stateUpdateMessage) {
+TEST(StateMachine, stateUpdateMessage)
+{
     StateMachine machine(2);
     canbus::Message msg;
     msg.time = base::Time::now();
@@ -57,7 +61,8 @@ TEST(StateMachine, stateUpdateMessage) {
     ASSERT_EQ(NODE_STOPPED, machine.getState());
 }
 
-TEST(StateMachine, stateUpdateFromAnotherNode) {
+TEST(StateMachine, stateUpdateFromAnotherNode)
+{
     StateMachine machine(2);
     canbus::Message msg;
     msg.time = base::Time::now();
@@ -67,7 +72,8 @@ TEST(StateMachine, stateUpdateFromAnotherNode) {
     ASSERT_EQ(false, machine.hasState());
 }
 
-TEST(StateMachine, processThrowsOnAnEmergencyMessage) {
+TEST(StateMachine, processThrowsOnAnEmergencyMessage)
+{
     StateMachine machine(2);
     canbus::Message msg;
     msg.time = base::Time::now();
@@ -76,10 +82,12 @@ TEST(StateMachine, processThrowsOnAnEmergencyMessage) {
     msg.data[1] = 0x10;
     msg.data[2] = 0xFA;
     ASSERT_THROW(machine.process(msg), EmergencyMessageReceived);
-    ASSERT_EQ(0xFA, machine.get<uint8_t>(ErrorRegister::OBJECT_ID, ErrorRegister::OBJECT_SUB_ID));
+    ASSERT_EQ(0xFA,
+        machine.get<uint8_t>(ErrorRegister::OBJECT_ID, ErrorRegister::OBJECT_SUB_ID));
 }
 
-TEST(StateMachine, processDoesNotThrowOnAnEmergencyWithZeroCode) {
+TEST(StateMachine, processDoesNotThrowOnAnEmergencyWithZeroCode)
+{
     StateMachine machine(2);
     canbus::Message msg;
     msg.time = base::Time::now();
@@ -89,7 +97,8 @@ TEST(StateMachine, processDoesNotThrowOnAnEmergencyWithZeroCode) {
     ASSERT_EQ(Update(StateMachine::PROCESSED_EMERGENCY_NO_ERROR), machine.process(msg));
 }
 
-TEST(StateMachine, processIgnoredEmergencyMessagesFromOtherNodes) {
+TEST(StateMachine, processIgnoredEmergencyMessagesFromOtherNodes)
+{
     StateMachine machine(2);
     canbus::Message msg;
     msg.time = base::Time::now();
@@ -99,80 +108,75 @@ TEST(StateMachine, processIgnoredEmergencyMessagesFromOtherNodes) {
     ASSERT_EQ(Update(StateMachine::PROCESSED_NOT_FOR_ME), machine.process(msg));
 }
 
-TEST(StateMachine, getNodeID) {
+TEST(StateMachine, getNodeID)
+{
     ASSERT_EQ(StateMachine(10).getNodeID(), 10);
 }
 
-TEST(StateMachine, upload) {
+TEST(StateMachine, upload)
+{
     StateMachine machine(2);
     canbus::Message msg = machine.upload(0x1801, 3);
     ASSERT_EQ(msg.can_id, 0x602);
     ASSERT_EQ(msg.size, 8);
-    EXPECT_THAT(
-        std::vector<uint8_t>(msg.data, msg.data + 8),
-        ElementsAre(0x40, 0x01, 0x18, 0x03, 0x00, 0x00, 0x00, 0x00)
-    );
+    EXPECT_THAT(std::vector<uint8_t>(msg.data, msg.data + 8),
+        ElementsAre(0x40, 0x01, 0x18, 0x03, 0x00, 0x00, 0x00, 0x00));
 }
 
-TEST(StateMachine, download) {
+TEST(StateMachine, download)
+{
     StateMachine machine(2);
     uint16_t value = 0x3FE;
     canbus::Message msg = machine.download(0x1801, 3, value);
     ASSERT_EQ(msg.can_id, 0x602);
     ASSERT_EQ(msg.size, 8);
-    EXPECT_THAT(
-        std::vector<uint8_t>(msg.data, msg.data + 8),
-        ElementsAre(0x2B, 0x01, 0x18, 0x03, 0xFE, 0x03, 0x00, 0x00)
-    );
+    EXPECT_THAT(std::vector<uint8_t>(msg.data, msg.data + 8),
+        ElementsAre(0x2B, 0x01, 0x18, 0x03, 0xFE, 0x03, 0x00, 0x00));
 }
 
-TEST(StateMachine, download_8) {
+TEST(StateMachine, download_8)
+{
     StateMachine machine(2);
     canbus::Message msg = machine.download<uint8_t>(0x1801, 3, 0xFE);
     ASSERT_EQ(msg.can_id, 0x602);
     ASSERT_EQ(msg.size, 8);
-    EXPECT_THAT(
-        std::vector<uint8_t>(msg.data, msg.data + 8),
-        ElementsAre(0x2F, 0x01, 0x18, 0x03, 0xFE, 0x00, 0x00, 0x00)
-    );
+    EXPECT_THAT(std::vector<uint8_t>(msg.data, msg.data + 8),
+        ElementsAre(0x2F, 0x01, 0x18, 0x03, 0xFE, 0x00, 0x00, 0x00));
 }
 
-TEST(StateMachine, download_16) {
+TEST(StateMachine, download_16)
+{
     StateMachine machine(2);
     canbus::Message msg = machine.download<uint16_t>(0x1801, 3, 0x1234);
     ASSERT_EQ(msg.can_id, 0x602);
     ASSERT_EQ(msg.size, 8);
-    EXPECT_THAT(
-        std::vector<uint8_t>(msg.data, msg.data + 8),
-        ElementsAre(0x2B, 0x01, 0x18, 0x03, 0x34, 0x12, 0x00, 0x00)
-    );
+    EXPECT_THAT(std::vector<uint8_t>(msg.data, msg.data + 8),
+        ElementsAre(0x2B, 0x01, 0x18, 0x03, 0x34, 0x12, 0x00, 0x00));
 }
 
-TEST(StateMachine, download_32) {
+TEST(StateMachine, download_32)
+{
     StateMachine machine(2);
     canbus::Message msg = machine.download<uint32_t>(0x1801, 3, 0x12345678);
     ASSERT_EQ(msg.can_id, 0x602);
     ASSERT_EQ(msg.size, 8);
-    EXPECT_THAT(
-        std::vector<uint8_t>(msg.data, msg.data + 8),
-        ElementsAre(0x23, 0x01, 0x18, 0x03, 0x78, 0x56, 0x34, 0x12)
-    );
+    EXPECT_THAT(std::vector<uint8_t>(msg.data, msg.data + 8),
+        ElementsAre(0x23, 0x01, 0x18, 0x03, 0x78, 0x56, 0x34, 0x12));
 }
 
-
-TEST(StateMachine, download_unknown) {
+TEST(StateMachine, download_unknown)
+{
     StateMachine machine(2, true);
-    std::vector<uint8_t> raw { 0xFE, 0x00, 0x00, 0x00 };
+    std::vector<uint8_t> raw{0xFE, 0x00, 0x00, 0x00};
     canbus::Message msg = machine.download(0x1801, 3, raw.data(), raw.size());
     ASSERT_EQ(msg.can_id, 0x602);
     ASSERT_EQ(msg.size, 8);
-    EXPECT_THAT(
-        std::vector<uint8_t>(msg.data, msg.data + 8),
-        ElementsAre(0x22, 0x01, 0x18, 0x03, 0xFE, 0x00, 0x00, 0x00)
-    );
+    EXPECT_THAT(std::vector<uint8_t>(msg.data, msg.data + 8),
+        ElementsAre(0x22, 0x01, 0x18, 0x03, 0xFE, 0x00, 0x00, 0x00));
 }
 
-TEST(StateMachine, set_and_get) {
+TEST(StateMachine, set_and_get)
+{
     StateMachine machine(2);
     uint16_t value = 0x1234;
     base::Time time = base::Time::fromSeconds(12);
@@ -181,7 +185,8 @@ TEST(StateMachine, set_and_get) {
     ASSERT_EQ(time, machine.timestamp(0x12, 0x1));
 }
 
-TEST(StateMachine, getDefinesSizeOfObject) {
+TEST(StateMachine, getDefinesSizeOfObject)
+{
     StateMachine machine(2, true);
     canbus::Message msg;
     msg.time = base::Time::now();
@@ -201,40 +206,42 @@ TEST(StateMachine, getDefinesSizeOfObject) {
     ASSERT_THROW(machine.get<uint8_t>(0x1801, 3), InvalidObjectType);
 }
 
-TEST(StateMachine, setRejectsZeroUpdateTime) {
+TEST(StateMachine, setRejectsZeroUpdateTime)
+{
     StateMachine machine(2);
     uint16_t value = 0x1234;
     ASSERT_THROW(machine.set(0x12, 0x1, value, base::Time()), std::invalid_argument);
 }
 
-TEST(StateMachine, getFailsOnADeclaredButUnreadObject) {
+TEST(StateMachine, getFailsOnADeclaredButUnreadObject)
+{
     StateMachine machine(2);
     machine.declare(0x1801, 3, 2);
     ASSERT_THROW(machine.get<uint16_t>(0x1801, 3), ObjectNotRead);
 }
 
-TEST(StateMachine, downloadOfADeclaredObject) {
+TEST(StateMachine, downloadOfADeclaredObject)
+{
     StateMachine machine(2);
     uint16_t value = 0x3FE;
     machine.declare(0x1801, 3, 2);
     canbus::Message msg = machine.download(0x1801, 3, value);
     ASSERT_EQ(msg.can_id, 0x602);
     ASSERT_EQ(msg.size, 8);
-    EXPECT_THAT(
-        std::vector<uint8_t>(msg.data, msg.data + 8),
-        ElementsAre(0x2B, 0x01, 0x18, 0x03, 0xFE, 0x03, 0x00, 0x00)
-    );
+    EXPECT_THAT(std::vector<uint8_t>(msg.data, msg.data + 8),
+        ElementsAre(0x2B, 0x01, 0x18, 0x03, 0xFE, 0x03, 0x00, 0x00));
 }
 
-TEST(StateMachine, downloadFailsIfDeclaredSizeMismatches) {
+TEST(StateMachine, downloadFailsIfDeclaredSizeMismatches)
+{
     StateMachine machine(2);
     machine.declare(0x1801, 3, 4);
-    ASSERT_THROW(
-        machine.download(0x1801, 3, static_cast<uint16_t>(0)),
+    ASSERT_THROW(machine.download(0x1801, 3, static_cast<uint16_t>(0)),
         ObjectSizeMismatch);
 }
 
-TEST(StateMachine, processUploadReply) {
+TEST(StateMachine, processUploadReply)
+{
     StateMachine machine(2);
     canbus::Message msg;
     msg.time = base::Time::now();
@@ -251,7 +258,8 @@ TEST(StateMachine, processUploadReply) {
     ASSERT_EQ(0x3FE, machine.get<uint16_t>(0x1801, 3));
 }
 
-TEST(StateMachine, processUnknownSizeUploadReply) {
+TEST(StateMachine, processUnknownSizeUploadReply)
+{
     StateMachine machine(2, true);
     canbus::Message msg;
     msg.time = base::Time::now();
@@ -271,7 +279,8 @@ TEST(StateMachine, processUnknownSizeUploadReply) {
     ASSERT_EQ(Update(StateMachine::PROCESSED_SDO, 0x1801, 3), machine.process(msg));
 }
 
-TEST(StateMachine, processUnknownSizeUploadReplyOfAnAlreadyDefinedObject) {
+TEST(StateMachine, processUnknownSizeUploadReplyOfAnAlreadyDefinedObject)
+{
     StateMachine machine(2, true);
     canbus::Message msg;
     msg.time = base::Time::now();
@@ -292,7 +301,8 @@ TEST(StateMachine, processUnknownSizeUploadReplyOfAnAlreadyDefinedObject) {
     ASSERT_EQ(0xBEEF, machine.get<uint16_t>(0x1801, 3));
 }
 
-TEST(StateMachine, processUploadReplyRejectsZeroUpdateTime) {
+TEST(StateMachine, processUploadReplyRejectsZeroUpdateTime)
+{
     StateMachine machine(2);
     canbus::Message msg;
     msg.time = base::Time();
@@ -350,21 +360,21 @@ TEST(StateMachine, configurePDOMapping)
     vector<canbus::Message> msg = machine.configurePDOMapping(true, 1, mappings);
     ASSERT_EQ(4, msg.size());
 
-    ASSERT_EQ(0x1A01,     fromLittleEndian<uint16_t>(msg[0].data + 1));
-    ASSERT_EQ(0,          msg[0].data[3]);
-    ASSERT_EQ(0,          fromLittleEndian<uint32_t>(msg[0].data + 4));
+    ASSERT_EQ(0x1A01, fromLittleEndian<uint16_t>(msg[0].data + 1));
+    ASSERT_EQ(0, msg[0].data[3]);
+    ASSERT_EQ(0, fromLittleEndian<uint32_t>(msg[0].data + 4));
 
-    ASSERT_EQ(0x1A01,     fromLittleEndian<uint16_t>(msg[1].data + 1));
-    ASSERT_EQ(1,          msg[1].data[3]);
+    ASSERT_EQ(0x1A01, fromLittleEndian<uint16_t>(msg[1].data + 1));
+    ASSERT_EQ(1, msg[1].data[3]);
     ASSERT_EQ(0x60000208, fromLittleEndian<uint32_t>(msg[1].data + 4));
 
-    ASSERT_EQ(0x1A01,     fromLittleEndian<uint16_t>(msg[2].data + 1));
-    ASSERT_EQ(2,          msg[2].data[3]);
+    ASSERT_EQ(0x1A01, fromLittleEndian<uint16_t>(msg[2].data + 1));
+    ASSERT_EQ(2, msg[2].data[3]);
     ASSERT_EQ(0x64010110, fromLittleEndian<uint32_t>(msg[2].data + 4));
 
-    ASSERT_EQ(0x1A01,     fromLittleEndian<uint16_t>(msg[3].data + 1));
-    ASSERT_EQ(0,          msg[0].data[3]);
-    ASSERT_EQ(2,          fromLittleEndian<uint32_t>(msg[3].data + 4));
+    ASSERT_EQ(0x1A01, fromLittleEndian<uint16_t>(msg[3].data + 1));
+    ASSERT_EQ(0, msg[0].data[3]);
+    ASSERT_EQ(2, fromLittleEndian<uint32_t>(msg[3].data + 4));
 }
 
 TEST(StateMachine, configurePDOMappingValidatesTheSizesMatchesDeclaredMappings)
@@ -373,8 +383,7 @@ TEST(StateMachine, configurePDOMappingValidatesTheSizesMatchesDeclaredMappings)
     mappings.add(0x6000, 0x02, 1);
     StateMachine machine(2);
     machine.declare(0x6000, 0x02, 2);
-    ASSERT_THROW(machine.configurePDOMapping(true, 1, mappings),
-        ObjectSizeMismatch);
+    ASSERT_THROW(machine.configurePDOMapping(true, 1, mappings), ObjectSizeMismatch);
 }
 
 TEST(StateMachine, processPDO)
@@ -435,12 +444,12 @@ TEST(StateMachine, configurePDOParameters_receive_asynchronous)
 
     ASSERT_EQ(2, messages.size());
     ASSERT_EQ(0x1401, fromLittleEndian<uint16_t>(messages[0].data + 1));
-    ASSERT_EQ(1,      fromLittleEndian<uint8_t>(messages[0].data + 3));
-    ASSERT_EQ(0x302,  fromLittleEndian<uint32_t>(messages[0].data + 4));
+    ASSERT_EQ(1, fromLittleEndian<uint8_t>(messages[0].data + 3));
+    ASSERT_EQ(0x302, fromLittleEndian<uint32_t>(messages[0].data + 4));
 
     ASSERT_EQ(0x1401, fromLittleEndian<uint16_t>(messages[1].data + 1));
-    ASSERT_EQ(2,      fromLittleEndian<uint8_t>(messages[1].data + 3));
-    ASSERT_EQ(254,    fromLittleEndian<uint8_t>(messages[1].data + 4));
+    ASSERT_EQ(2, fromLittleEndian<uint8_t>(messages[1].data + 3));
+    ASSERT_EQ(254, fromLittleEndian<uint8_t>(messages[1].data + 4));
 }
 
 TEST(StateMachine, configurePDOParameters_transmit_synchronous)
@@ -455,15 +464,16 @@ TEST(StateMachine, configurePDOParameters_transmit_synchronous)
 
     ASSERT_EQ(2, messages.size());
     ASSERT_EQ(0x1801, fromLittleEndian<uint16_t>(messages[0].data + 1));
-    ASSERT_EQ(1,      fromLittleEndian<uint8_t>(messages[0].data + 3));
-    ASSERT_EQ(0x282,  fromLittleEndian<uint32_t>(messages[0].data + 4));
+    ASSERT_EQ(1, fromLittleEndian<uint8_t>(messages[0].data + 3));
+    ASSERT_EQ(0x282, fromLittleEndian<uint32_t>(messages[0].data + 4));
 
     ASSERT_EQ(0x1801, fromLittleEndian<uint16_t>(messages[1].data + 1));
-    ASSERT_EQ(2,      fromLittleEndian<uint8_t>(messages[1].data + 3));
-    ASSERT_EQ(10,     fromLittleEndian<uint8_t>(messages[1].data + 4));
+    ASSERT_EQ(2, fromLittleEndian<uint8_t>(messages[1].data + 3));
+    ASSERT_EQ(10, fromLittleEndian<uint8_t>(messages[1].data + 4));
 }
 
-TEST(StateMachine, configurePDOParameters_transmit_cyclic_synchronous_rejects_invalid_cycle)
+TEST(StateMachine,
+    configurePDOParameters_transmit_cyclic_synchronous_rejects_invalid_cycle)
 {
     StateMachine machine(2);
     PDOCommunicationParameters parameters;
@@ -486,20 +496,20 @@ TEST(StateMachine, configurePDOParameters_transmit_asynchronous_aperiodic)
 
     ASSERT_EQ(4, messages.size());
     ASSERT_EQ(0x1801, fromLittleEndian<uint16_t>(messages[0].data + 1));
-    ASSERT_EQ(1,      fromLittleEndian<uint8_t>(messages[0].data + 3));
-    ASSERT_EQ(0x282,  fromLittleEndian<uint32_t>(messages[0].data + 4));
+    ASSERT_EQ(1, fromLittleEndian<uint8_t>(messages[0].data + 3));
+    ASSERT_EQ(0x282, fromLittleEndian<uint32_t>(messages[0].data + 4));
 
     ASSERT_EQ(0x1801, fromLittleEndian<uint16_t>(messages[1].data + 1));
-    ASSERT_EQ(2,      fromLittleEndian<uint8_t>(messages[1].data + 3));
-    ASSERT_EQ(254,    fromLittleEndian<uint8_t>(messages[1].data + 4));
+    ASSERT_EQ(2, fromLittleEndian<uint8_t>(messages[1].data + 3));
+    ASSERT_EQ(254, fromLittleEndian<uint8_t>(messages[1].data + 4));
 
     ASSERT_EQ(0x1801, fromLittleEndian<uint16_t>(messages[2].data + 1));
-    ASSERT_EQ(3,      fromLittleEndian<uint8_t>(messages[2].data + 3));
-    ASSERT_EQ(100,    fromLittleEndian<uint16_t>(messages[2].data + 4));
+    ASSERT_EQ(3, fromLittleEndian<uint8_t>(messages[2].data + 3));
+    ASSERT_EQ(100, fromLittleEndian<uint16_t>(messages[2].data + 4));
 
     ASSERT_EQ(0x1801, fromLittleEndian<uint16_t>(messages[3].data + 1));
-    ASSERT_EQ(5,      fromLittleEndian<uint8_t>(messages[3].data + 3));
-    ASSERT_EQ(0,      fromLittleEndian<uint16_t>(messages[3].data + 4));
+    ASSERT_EQ(5, fromLittleEndian<uint8_t>(messages[3].data + 3));
+    ASSERT_EQ(0, fromLittleEndian<uint16_t>(messages[3].data + 4));
 }
 
 TEST(StateMachine, configurePDOParameters_transmit_asynchronous_periodic)
@@ -515,20 +525,20 @@ TEST(StateMachine, configurePDOParameters_transmit_asynchronous_periodic)
 
     ASSERT_EQ(4, messages.size());
     ASSERT_EQ(0x1801, fromLittleEndian<uint16_t>(messages[0].data + 1));
-    ASSERT_EQ(1,      fromLittleEndian<uint8_t>(messages[0].data + 3));
-    ASSERT_EQ(0x282,  fromLittleEndian<uint32_t>(messages[0].data + 4));
+    ASSERT_EQ(1, fromLittleEndian<uint8_t>(messages[0].data + 3));
+    ASSERT_EQ(0x282, fromLittleEndian<uint32_t>(messages[0].data + 4));
 
     ASSERT_EQ(0x1801, fromLittleEndian<uint16_t>(messages[1].data + 1));
-    ASSERT_EQ(2,      fromLittleEndian<uint8_t>(messages[1].data + 3));
-    ASSERT_EQ(254,    fromLittleEndian<uint8_t>(messages[1].data + 4));
+    ASSERT_EQ(2, fromLittleEndian<uint8_t>(messages[1].data + 3));
+    ASSERT_EQ(254, fromLittleEndian<uint8_t>(messages[1].data + 4));
 
     ASSERT_EQ(0x1801, fromLittleEndian<uint16_t>(messages[2].data + 1));
-    ASSERT_EQ(3,      fromLittleEndian<uint8_t>(messages[2].data + 3));
-    ASSERT_EQ(100,    fromLittleEndian<uint16_t>(messages[2].data + 4));
+    ASSERT_EQ(3, fromLittleEndian<uint8_t>(messages[2].data + 3));
+    ASSERT_EQ(100, fromLittleEndian<uint16_t>(messages[2].data + 4));
 
     ASSERT_EQ(0x1801, fromLittleEndian<uint16_t>(messages[3].data + 1));
-    ASSERT_EQ(5,      fromLittleEndian<uint8_t>(messages[3].data + 3));
-    ASSERT_EQ(10,     fromLittleEndian<uint16_t>(messages[3].data + 4));
+    ASSERT_EQ(5, fromLittleEndian<uint8_t>(messages[3].data + 3));
+    ASSERT_EQ(10, fromLittleEndian<uint16_t>(messages[3].data + 4));
 }
 
 TEST(StateMachine, configurePDOParameters_transmit_asynchronous_validates_inhibit_time)
@@ -565,45 +575,44 @@ TEST(StateMachine, configurePDO)
     mappings.add(0x6401, 0x01, 2);
 
     StateMachine machine(2);
-    vector<canbus::Message> msg =
-        machine.configurePDO(true, 1, parameters, mappings);
+    vector<canbus::Message> msg = machine.configurePDO(true, 1, parameters, mappings);
     ASSERT_EQ(9, msg.size());
 
-    ASSERT_EQ(0x1801,     fromLittleEndian<uint16_t>(msg[0].data + 1));
-    ASSERT_EQ(1,          fromLittleEndian<uint8_t>(msg[0].data + 3));
+    ASSERT_EQ(0x1801, fromLittleEndian<uint16_t>(msg[0].data + 1));
+    ASSERT_EQ(1, fromLittleEndian<uint8_t>(msg[0].data + 3));
     ASSERT_EQ(0x80000282, fromLittleEndian<uint32_t>(msg[0].data + 4));
 
-    ASSERT_EQ(0x1801,     fromLittleEndian<uint16_t>(msg[1].data + 1));
-    ASSERT_EQ(2,          fromLittleEndian<uint8_t>(msg[1].data + 3));
-    ASSERT_EQ(254,        fromLittleEndian<uint8_t>(msg[1].data + 4));
+    ASSERT_EQ(0x1801, fromLittleEndian<uint16_t>(msg[1].data + 1));
+    ASSERT_EQ(2, fromLittleEndian<uint8_t>(msg[1].data + 3));
+    ASSERT_EQ(254, fromLittleEndian<uint8_t>(msg[1].data + 4));
 
-    ASSERT_EQ(0x1801,     fromLittleEndian<uint16_t>(msg[2].data + 1));
-    ASSERT_EQ(3,          fromLittleEndian<uint8_t>(msg[2].data + 3));
-    ASSERT_EQ(100,        fromLittleEndian<uint16_t>(msg[2].data + 4));
+    ASSERT_EQ(0x1801, fromLittleEndian<uint16_t>(msg[2].data + 1));
+    ASSERT_EQ(3, fromLittleEndian<uint8_t>(msg[2].data + 3));
+    ASSERT_EQ(100, fromLittleEndian<uint16_t>(msg[2].data + 4));
 
-    ASSERT_EQ(0x1801,     fromLittleEndian<uint16_t>(msg[3].data + 1));
-    ASSERT_EQ(5,          fromLittleEndian<uint8_t>(msg[3].data + 3));
-    ASSERT_EQ(10,         fromLittleEndian<uint16_t>(msg[3].data + 4));
+    ASSERT_EQ(0x1801, fromLittleEndian<uint16_t>(msg[3].data + 1));
+    ASSERT_EQ(5, fromLittleEndian<uint8_t>(msg[3].data + 3));
+    ASSERT_EQ(10, fromLittleEndian<uint16_t>(msg[3].data + 4));
 
-    ASSERT_EQ(0x1A01,     fromLittleEndian<uint16_t>(msg[4].data + 1));
-    ASSERT_EQ(0,          msg[4].data[3]);
-    ASSERT_EQ(0,          fromLittleEndian<uint32_t>(msg[4].data + 4));
+    ASSERT_EQ(0x1A01, fromLittleEndian<uint16_t>(msg[4].data + 1));
+    ASSERT_EQ(0, msg[4].data[3]);
+    ASSERT_EQ(0, fromLittleEndian<uint32_t>(msg[4].data + 4));
 
-    ASSERT_EQ(0x1A01,     fromLittleEndian<uint16_t>(msg[5].data + 1));
-    ASSERT_EQ(1,          msg[5].data[3]);
+    ASSERT_EQ(0x1A01, fromLittleEndian<uint16_t>(msg[5].data + 1));
+    ASSERT_EQ(1, msg[5].data[3]);
     ASSERT_EQ(0x60000208, fromLittleEndian<uint32_t>(msg[5].data + 4));
 
-    ASSERT_EQ(0x1A01,     fromLittleEndian<uint16_t>(msg[6].data + 1));
-    ASSERT_EQ(2,          msg[6].data[3]);
+    ASSERT_EQ(0x1A01, fromLittleEndian<uint16_t>(msg[6].data + 1));
+    ASSERT_EQ(2, msg[6].data[3]);
     ASSERT_EQ(0x64010110, fromLittleEndian<uint32_t>(msg[6].data + 4));
 
-    ASSERT_EQ(0x1A01,     fromLittleEndian<uint16_t>(msg[7].data + 1));
-    ASSERT_EQ(0,          msg[7].data[3]);
-    ASSERT_EQ(2,          fromLittleEndian<uint32_t>(msg[7].data + 4));
+    ASSERT_EQ(0x1A01, fromLittleEndian<uint16_t>(msg[7].data + 1));
+    ASSERT_EQ(0, msg[7].data[3]);
+    ASSERT_EQ(2, fromLittleEndian<uint32_t>(msg[7].data + 4));
 
-    ASSERT_EQ(0x1801,     fromLittleEndian<uint16_t>(msg[8].data + 1));
-    ASSERT_EQ(1,          fromLittleEndian<uint8_t>(msg[8].data + 3));
-    ASSERT_EQ(0x282,      fromLittleEndian<uint32_t>(msg[8].data + 4));
+    ASSERT_EQ(0x1801, fromLittleEndian<uint16_t>(msg[8].data + 1));
+    ASSERT_EQ(1, fromLittleEndian<uint8_t>(msg[8].data + 3));
+    ASSERT_EQ(0x282, fromLittleEndian<uint32_t>(msg[8].data + 4));
 }
 
 TEST(StateMachine, configurePDO_COBID_MESSAGE_RESERVED_BIT_QUIRK)
@@ -617,17 +626,16 @@ TEST(StateMachine, configurePDO_COBID_MESSAGE_RESERVED_BIT_QUIRK)
 
     StateMachine machine(2);
     machine.setQuirks(StateMachine::PDO_COBID_MESSAGE_RESERVED_BIT_QUIRK);
-    vector<canbus::Message> msg =
-        machine.configurePDO(true, 1, parameters, mappings);
+    vector<canbus::Message> msg = machine.configurePDO(true, 1, parameters, mappings);
 
     ASSERT_EQ(9, msg.size());
 
-    ASSERT_EQ(0x1801,     fromLittleEndian<uint16_t>(msg[0].data + 1));
-    ASSERT_EQ(1,          fromLittleEndian<uint8_t>(msg[0].data + 3));
+    ASSERT_EQ(0x1801, fromLittleEndian<uint16_t>(msg[0].data + 1));
+    ASSERT_EQ(1, fromLittleEndian<uint8_t>(msg[0].data + 3));
     ASSERT_EQ(0xC0000282, fromLittleEndian<uint32_t>(msg[0].data + 4));
 
-    ASSERT_EQ(0x1801,     fromLittleEndian<uint16_t>(msg[8].data + 1));
-    ASSERT_EQ(1,          fromLittleEndian<uint8_t>(msg[8].data + 3));
+    ASSERT_EQ(0x1801, fromLittleEndian<uint16_t>(msg[8].data + 1));
+    ASSERT_EQ(1, fromLittleEndian<uint8_t>(msg[8].data + 3));
     ASSERT_EQ(0x40000282, fromLittleEndian<uint32_t>(msg[8].data + 4));
 }
 
@@ -636,8 +644,8 @@ TEST(StateMachine, disablePDO)
     StateMachine machine(2);
     canbus::Message msg = machine.disablePDO(true, 1);
 
-    ASSERT_EQ(0x1801,     fromLittleEndian<uint16_t>(msg.data + 1));
-    ASSERT_EQ(1,          fromLittleEndian<uint8_t>(msg.data + 3));
+    ASSERT_EQ(0x1801, fromLittleEndian<uint16_t>(msg.data + 1));
+    ASSERT_EQ(1, fromLittleEndian<uint8_t>(msg.data + 3));
     ASSERT_EQ(0x80000282, fromLittleEndian<uint32_t>(msg.data + 4));
 }
 
@@ -647,33 +655,38 @@ TEST(StateMachine, disablePDO_PDO_COBID_MESSAGE_RESERVED_BIT_QUIRK)
     machine.setQuirks(StateMachine::PDO_COBID_MESSAGE_RESERVED_BIT_QUIRK);
     canbus::Message msg = machine.disablePDO(true, 1);
 
-    ASSERT_EQ(0x1801,     fromLittleEndian<uint16_t>(msg.data + 1));
-    ASSERT_EQ(1,          fromLittleEndian<uint8_t>(msg.data + 3));
+    ASSERT_EQ(0x1801, fromLittleEndian<uint16_t>(msg.data + 1));
+    ASSERT_EQ(1, fromLittleEndian<uint8_t>(msg.data + 3));
     ASSERT_EQ(0xC0000282, fromLittleEndian<uint32_t>(msg.data + 4));
 }
-TEST(Update, it_is_reporting_IGNORED_MESSAGE_by_default) {
+TEST(Update, it_is_reporting_IGNORED_MESSAGE_by_default)
+{
     Update update;
     ASSERT_EQ(StateMachine::PROCESSED_IGNORED_MESSAGE, update.mode);
 }
 
-TEST(Update, it_has_no_updated_objects_by_default) {
+TEST(Update, it_has_no_updated_objects_by_default)
+{
     Update update;
     ASSERT_FALSE(update.hasUpdatedObjects());
 }
 
-TEST(Update, it_reports_that_it_has_updated_objects_once_some_are_added) {
+TEST(Update, it_reports_that_it_has_updated_objects_once_some_are_added)
+{
     Update update;
     update.addUpdate(10, 20);
     ASSERT_TRUE(update.hasUpdatedObjects());
 }
 
-TEST(Update, it_reports_if_an_object_has_been_updated) {
+TEST(Update, it_reports_if_an_object_has_been_updated)
+{
     Update update;
     update.addUpdate(10, 20);
     ASSERT_TRUE(update.hasUpdatedObject(10, 20));
 }
 
-TEST(Update, it_handles_multiple_objects) {
+TEST(Update, it_handles_multiple_objects)
+{
     Update update;
     update.addUpdate(10, 20);
     update.addUpdate(11, 21);
@@ -688,37 +701,43 @@ struct DictionaryObject {
     static const int OBJECT_SUB_ID = 20;
 };
 
-TEST(Update, it_adds_an_update_with_a_dictionary_type) {
+TEST(Update, it_adds_an_update_with_a_dictionary_type)
+{
     Update update;
     update.addUpdate<DictionaryObject>();
     ASSERT_TRUE(update.hasUpdatedObject(10, 20));
 }
 
-TEST(Update, it_accepts_an_id_offset_when_adding_an_update_with_a_dictionary_type) {
+TEST(Update, it_accepts_an_id_offset_when_adding_an_update_with_a_dictionary_type)
+{
     Update update;
     update.addUpdate<DictionaryObject>(5, 0);
     ASSERT_TRUE(update.hasUpdatedObject(15, 20));
 }
 
-TEST(Update, it_accepts_a_sub_id_offset_when_adding_an_update_with_a_dictionary_type) {
+TEST(Update, it_accepts_a_sub_id_offset_when_adding_an_update_with_a_dictionary_type)
+{
     Update update;
     update.addUpdate<DictionaryObject>(0, 5);
     ASSERT_TRUE(update.hasUpdatedObject(10, 25));
 }
 
-TEST(Update, it_can_be_queried_with_a_dictionary_type) {
+TEST(Update, it_can_be_queried_with_a_dictionary_type)
+{
     Update update;
     update.addUpdate(10, 20);
     ASSERT_TRUE(update.hasUpdatedObject<DictionaryObject>());
 }
 
-TEST(Update, it_accepts_an_object_id_offset_when_queries_with_a_dictionary_type) {
+TEST(Update, it_accepts_an_object_id_offset_when_queries_with_a_dictionary_type)
+{
     Update update;
     update.addUpdate(10, 25);
     ASSERT_TRUE(update.hasUpdatedObject<DictionaryObject>(0, 5));
 }
 
-TEST(Update, it_accepts_an_object_sub_id_offset_when_queries_with_a_dictionary_type) {
+TEST(Update, it_accepts_an_object_sub_id_offset_when_queries_with_a_dictionary_type)
+{
     Update update;
     update.addUpdate(15, 20);
     ASSERT_TRUE(update.hasUpdatedObject<DictionaryObject>(5, 0));


### PR DESCRIPTION
This facilitates backward compatibility when objects change size.